### PR TITLE
Split servers/users in M-Line

### DIFF
--- a/common/struct_def.h
+++ b/common/struct_def.h
@@ -1002,7 +1002,6 @@ typedef enum ServerChannels {
 #define TSET_ACONNECT 0x001
 #define TSET_POOLSIZE 0x002
 #define TSET_CACCEPT 0x004
-#define TSET_SPLIT 0x008
 #define TSET_SHOWALL (int) ~0
 
 /* Runtime configuration structure */

--- a/doc/confsplit.txt
+++ b/doc/confsplit.txt
@@ -1,0 +1,76 @@
+######################################################################
+
+confsplit - SS/SU values in ircd.conf
+
+######################################################################
+
+This patch adds split-servers and split-users to ircd.conf to change
+values without recompiling the ircd.
+
+Two new MANDATORY fields have been added to the M-line after the SID:
+
+ M:<Server NAME>:<YOUR Internet IP#>:<Geographic Location>:<Port>
+  :<SID>:<SS>:<SU>:
+
+These values will be applied on server startup and on /REHASH.
+Note that they will still respect the minimum limits set in
+config.h defines SPLIT_SERVERS and SPLIT_USERS.
+
+example:
+
+ M:irc.example.net:127.0.0.1:Example server:6667:0PNX:10:10000:
+
+ Will set the split-servers (SS) current value to 10 servers minimum
+ and split-users (SU) current value to 10000 users minimum, then do
+ a check for split-mode.
+
+######################################################################
+
+changelog:
+
+ v1.03
+
+ 2024-09-23 -- patrick
+  * made SS/SU fields mandatory in ircd.conf
+  * always read new values on /REHASH, removed CONFSPLIT_*
+
+ v1.02
+
+ 2020-01-24 -- mh
+
+  * support/config.h.dist: made CONFSPLIT_REHASH undefine look less
+    silly
+
+  * ircd/s_conf.c:initconf(): added DEFAULT_SPLIT_* values to notice
+    when changing values in a rehash
+
+  * ircd/s_conf.c:initconf(): split check is only needed in a rehash,
+    not on server (re)start - same for notices to &notices. fixed
+
+ v1.01
+
+ 2020-01-23 -- mh
+
+  * common/patchlevel.h added CONFSPLIT_VERSION for good measure
+
+  * ircd/s_debug.c: 'o' (CONFSPLIT defined) and 'O' (CONFSPLIT and
+    CONFSPLIT_REHASH defined) serveropts added. they will show in
+    /VERSION and can be V-lined if one so desire.
+
+ v1.00
+
+ 2020-01-23 -- mh
+
+  * added the option to only apply the SS/SU values at server startup
+    and not during /REHASH (CONFSPLIT_REHASH define)
+
+ 2020-01-22 -- mh
+
+  * ircd/s_conf.c:initconf() added 2 more fields to M-line after SID.
+    SS and SU values respectively. these will be used on startup and
+    on /REHASH. the values are checked against minimum defined values
+    (SPLIT_SERVERS and SPLIT_USERS) before being applied.
+
+  * project started
+
+######################################################################

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -57,7 +57,7 @@
 # the server listens for UDP pings (used to determine the fastest link in a
 # class when autoconnecting)
 #
-# M:<Server NAME>:<YOUR Internet IP#>:<Geographic Location>:<Port>:<SID>:
+# M:<Server NAME>:<YOUR Internet IP#>:<Geographic Location>:<Port>:<SID>:<Split Servers>:<Split Users>:
 #
 # Note that 'server name' refers to the name of the irc-server which needs 
 # not to be the same as the hostname of the machine it's running on.
@@ -66,14 +66,16 @@
 # your local coord. If you are (BIC) Coord on IRCnet, you have a pool of
 # 36 SIDs to choose from. Check doc/ISO-3166-1 file to find your country
 # numeric code (example: 000) and assign one SID for every of your servers
-# starting from 000A, through 000Z, 0000 and ending at 0009.
+# starting from 000A, through 000Z, 0000 and ending at 0009. 'Split Servers'
+# and 'Split Users' define thresholds for turning on and off the split-mode,
+# where joins to new channels do not give chanop status.
 #
 # This let's ircd use the primary ip of your host to establish connections
-M:example.irc.org::Example Geographic Location, Planet Earth:6667:000A
+M:example.irc.org::Example Geographic Location, Planet Earth:6667:000A:0:0:
 #
 # This let's ircd use the ip 127.0.0.2 to establish connections, useful
 # if you're running virtual interfaces
-#M:example.irc.org:127.0.0.2:Example Geographic Location, Planet Earth:6667:000A:
+#M:example.irc.org:127.0.0.2:Example Geographic Location, Planet Earth:6667:000A:0:0:
 #
 #
 ############################

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -1082,6 +1082,11 @@ int	main(int argc, char *argv[])
 			fprintf(stderr,
 			"Warning: Network name is not set in ircd.conf\n");
 		}
+		if(iconf.split_minservers == -1 || iconf.split_minusers == -1)
+		{
+			fprintf(stderr, "Fatal Error: split servers and users are not set in ircd.conf\n");
+			exit(-1);
+		}
 		isupport = make_isupport();	/* Generate RPL_ISUPPORT (005) numerics */
 	    }
 

--- a/ircd/s_misc.c
+++ b/ircd/s_misc.c
@@ -1009,14 +1009,8 @@ void	initruntimeconf(void)
 	iconf.aconnect = 1; /* default to ON */
 	iconf.split = 1; /* ircd starts in split-mode */
 	iconf.caccept = 2; /* accept clients when no split */
-
-	/* Defaults set in config.h */
-	/*
-	 * 2011-01-20  Piotr Kucharski
-	 *  * s_misc.c/initruntimeconf(): take max of SPLIT_ and DEFAULT_SPLIT_*.
-	 */
-	iconf.split_minservers = MAX(DEFAULT_SPLIT_SERVERS, SPLIT_SERVERS);
-	iconf.split_minusers = MAX(DEFAULT_SPLIT_USERS, SPLIT_USERS);
+	iconf.split_minservers = -1; /* must be specified in ircd.conf */
+	iconf.split_minusers = -1; /* must be specified in ircd.conf */
 
 	if ((bootopt & BOOT_STANDALONE))
 	{

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -3215,7 +3215,6 @@ int	m_set(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{ TSET_POOLSIZE, "POOLSIZE" },
 		{ TSET_ACONNECT, "ACONNECT" },
 		{ TSET_CACCEPT, "CACCEPT" },
-		{ TSET_SPLIT, "SPLIT" },
 		{ 0, NULL }
 	};
 	int i, acmd = 0;
@@ -3330,40 +3329,6 @@ int	m_set(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				sendto_flag(SCH_NOTICE, "%s changed value of "
 					"CACCEPT to %s", sptr->name, parv[2]);
 				break;
-			case TSET_SPLIT:
-			{
-				int tmp;
-
-				tmp = atoi(parv[2]);
-				if (tmp < SPLIT_SERVERS)
-					tmp = SPLIT_SERVERS;
-				if (tmp != iconf.split_minservers)
-				{
-					sendto_flag(SCH_NOTICE, "%s changed"
-						" value of SPLIT_SERVERS"
-						" from %d to %d", sptr->name,
-						iconf.split_minservers, tmp);
-					iconf.split_minservers = tmp;
-				}
-				if (parc > 3)
-				{
-					tmp = atoi(parv[3]);
-					if (tmp < SPLIT_USERS)
-						tmp = SPLIT_USERS;
-				}
-				else
-					tmp = iconf.split_minusers;
-				if (tmp != iconf.split_minusers)
-				{
-					sendto_flag(SCH_NOTICE, "%s changed"
-						" value of SPLIT_USERS"
-						" from %d to %d", sptr->name,
-						iconf.split_minusers, tmp);
-					iconf.split_minusers = tmp;
-				}
-				check_split();
-				break;
-			}
 		} /* switch(acmd) */
 	} /* parc > 2 */
 
@@ -3385,12 +3350,6 @@ int	m_set(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			sendto_one(sptr, ":%s NOTICE %s :CACCEPT = %s", ME,
 				parv[0], iconf.caccept == 2 ? "SPLIT" :
 				iconf.caccept == 1 ? "ON" : "OFF");
-		}
-		if (acmd & TSET_SPLIT)
-		{
-			sendto_one(sptr, ":%s NOTICE %s :SPLIT = SS %d SU %d",
-				ME, parv[0], iconf.split_minservers,
-				iconf.split_minusers);
 		}
 	}
 	return 1;

--- a/support/config.h.dist
+++ b/support/config.h.dist
@@ -785,8 +785,8 @@
 #define CACCEPT_DEFAULT 2
 
 /* Minimum values admin can set. */
-#define SPLIT_USERS	50000
-#define SPLIT_SERVERS	50
+#define SPLIT_USERS 5000
+#define SPLIT_SERVERS	10
 
 /************************************************************************
  *

--- a/support/config.h.dist
+++ b/support/config.h.dist
@@ -543,8 +543,6 @@
  *
  * Defining to 0 disables entering split-mode.
  */
-#define DEFAULT_SPLIT_USERS	65000
-#define DEFAULT_SPLIT_SERVERS	80
 
 /*
 ** Notice sent to connecting users if the server is in the split-mode.


### PR DESCRIPTION
* Added two new mandatory fields for split servers and split users to M-Line (original code from mh)
* Removed `SET SPLIT`
* Removed DEFAULT_SPLIT_USERS and DEFAULT_SPLIT_SERVERS

```
######################################################################

confsplit - SS/SU values in ircd.conf

######################################################################

This patch adds split-servers and split-users to ircd.conf to change
values without recompiling the ircd.

Two new MANDATORY fields have been added to the M-line after the SID:

 M:<Server NAME>:<YOUR Internet IP#>:<Geographic Location>:<Port>
  :<SID>:<SS>:<SU>:

These values will be applied on server startup and on /REHASH.
Note that they will still respect the minimum limits set in
config.h defines SPLIT_SERVERS and SPLIT_USERS.

example:

 M:irc.example.net:127.0.0.1:Example server:6667:0PNX:10:10000:

 Will set the split-servers (SS) current value to 10 servers minimum
 and split-users (SU) current value to 10000 users minimum, then do
 a check for split-mode.

######################################################################

```