### PR TITLE
Made the following channels oper-only: &DEBUG, &ERRORS, &HASH, &LOCAL…

### DIFF
--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -733,7 +733,7 @@ void	setup_server_channels(aClient *mp)
 	chptr = get_channel(mp, "&ERRORS", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: server errors");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
-	chptr->mode.mode = smode;
+	chptr->mode.mode = smode|MODE_SECRET|MODE_INVITEONLY;
 	chptr = get_channel(mp, "&NOTICES", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: warnings and notices");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
@@ -757,11 +757,11 @@ void	setup_server_channels(aClient *mp)
 	chptr = get_channel(mp, "&HASH", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: hash tables growth");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
-	chptr->mode.mode = smode;
+	chptr->mode.mode = smode|MODE_SECRET|MODE_INVITEONLY;
 	chptr = get_channel(mp, "&LOCAL", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: notices about local connections");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
-	chptr->mode.mode = smode;
+	chptr->mode.mode = smode|MODE_SECRET|MODE_INVITEONLY;
 	chptr = get_channel(mp, "&SERVICES", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: services joining and leaving");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
@@ -771,7 +771,7 @@ void	setup_server_channels(aClient *mp)
 	strcpy(chptr->topic,
 	       "SERVER MESSAGES: messages from the authentication slave");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
-	chptr->mode.mode = smode;
+	chptr->mode.mode = smode|MODE_SECRET|MODE_INVITEONLY;
 #endif
 	chptr = get_channel(mp, "&SAVE", CREATE);
 	strcpy(chptr->topic,
@@ -781,7 +781,7 @@ void	setup_server_channels(aClient *mp)
 	chptr = get_channel(mp, "&DEBUG", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: debug messages [you shouldn't be here! ;)]");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
-	chptr->mode.mode = smode|MODE_SECRET;
+	chptr->mode.mode = smode|MODE_SECRET|MODE_INVITEONLY;
 	chptr = get_channel(mp, "&WALLOPS", CREATE);
 	strcpy(chptr->topic, "SERVER MESSAGES: wallops received");
 	add_user_to_channel(chptr, mp, CHFL_CHANOP);
@@ -2002,8 +2002,16 @@ static	int	can_join(aClient *sptr, aChannel *chptr, char *key)
 		&& is_allowed(sptr, ACL_CLIENTS))
 		return 0;
 #endif
-	if (*chptr->chname == '&' && !strcmp(chptr->chname, "&OPER")
-		&& IsAnOper(sptr))
+	if (*chptr->chname == '&'
+		&& (!strcmp(chptr->chname, "&DEBUG")
+			|| !strcmp(chptr->chname, "&ERRORS")
+			|| !strcmp(chptr->chname, "&HASH")
+			|| !strcmp(chptr->chname, "&LOCAL")
+			|| !strcmp(chptr->chname, "&OPER")
+#if defined(USE_IAUTH)
+			|| !strcmp(chptr->chname, "&AUTH")
+#endif
+			) && IsAnOper(sptr))
 		return 0;
 
 	for (lp = sptr->user->invited; lp; lp = lp->next)


### PR DESCRIPTION
The following local channels are now available only for IRC operators.
* &DEBUG
* &ERRORS
* &HASH
* **&LOCAL**
* &AUTH

The reason is that these channel expose IP addresses of users who did manage to connect or that they report information that are not relevant for users.

## &LOCAL
```
15:12 !Uni-Erlangen.DE Unauthorized connection from nick[@1.2.3.4].
15:13 !Uni-Erlangen.DE Too many host connections (local) from mukka2[@1.2.3.4].
15:14 !Uni-Erlangen.DE K-lined ~tip@1.2.3.4.
15:14 !Uni-Erlangen.DE Invalid username:  $@1.2.3.4.
```

## &ERRORS
```
15:15 !Uni-Erlangen.DE Bad hostname returned for 1.2.3.4
```