### PR TITLE
Whox

### DIFF
--- a/common/numeric_def.h
+++ b/common/numeric_def.h
@@ -264,6 +264,7 @@
 #define RPL_WHOREPLY         352
 #define RPL_ENDOFWHO         315
 #define RPL_NAMREPLY         353
+#define RPL_WHOSPCRPL        354
 #define RPL_ENDOFNAMES       366
 
 #define RPL_KILLDONE         361

--- a/common/struct_def.h
+++ b/common/struct_def.h
@@ -992,6 +992,30 @@ typedef enum ServerChannels {
 #   error LOCALNICKLEN must not be bigger than NICKLEN
 #endif
 
+/* WHO parameter flags */
+#define WHO_FLAG_OPERS_ONLY	0x0001
+#define WHO_FLAG_CHANNEL	0x0002
+#define WHO_FLAG_HOP		0x0004
+#define WHO_FLAG_FLAGS		0x0008
+#define WHO_FLAG_HOST		0x0010
+#define WHO_FLAG_IP			0x0020
+#define WHO_FLAG_IDLE		0x0040
+#define WHO_FLAG_NICK		0x0080
+#define WHO_FLAG_INFO		0x0100
+#define WHO_FLAG_SERVER		0x0200
+#define WHO_FLAG_TOKEN		0x0400
+#define WHO_FLAG_USER		0x0800
+#define WHO_FLAG_ACCOUNT	0x1000
+#define WHO_FLAG_OP_LEVEL	0x2000
+#define WHO_FLAG_SID		0x4000
+#define WHO_FLAG_UID		0x8000
+
+struct who_opts
+{
+	int flags;
+	const char *token;
+};
+
 /*
  * base for channel IDs and UIDs
  */

--- a/common/support.c
+++ b/common/support.c
@@ -137,6 +137,23 @@ char	*strtok(char *str, const char *fs)
 
 #endif /* HAVE_STRTOK */
 
+int snprintf_append(char *str, int size, int pos, const char *fmt, ...)
+{
+	int ret, max;
+
+	if(pos >= size)
+		return 0;
+	else
+		max = size - pos;
+
+	va_list ap;
+	va_start(ap, fmt);
+	ret = vsnprintf(str + pos, max, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
 #if !defined(HAVE_STRERROR)
 /*
 **	strerror - return an appropriate system error string to a given errno

--- a/common/support.c
+++ b/common/support.c
@@ -837,7 +837,7 @@ char	**make_isupport(void)
 		LOCALNICKLEN, TOPICLEN, TOPICLEN, MAXBANS, CHANNELLEN, CHIDLEN);
 
 	tis[1] = (char *) MyMalloc(BUFSIZE);
-	sprintf(tis[1],	"PENALTY FNC EXCEPTS=e INVEX=I CASEMAPPING=ascii");
+	sprintf(tis[1],	"PENALTY FNC WHOX EXCEPTS=e INVEX=I CASEMAPPING=ascii");
 	if (networkname)
 	{
 		strcat(tis[1], " NETWORK=");

--- a/common/support_ext.h
+++ b/common/support_ext.h
@@ -42,6 +42,7 @@ EXTERN char *strtoken (char **save, char *str, char *fs);
  */
 EXTERN char *strtok (char *str, const char *fs);
 #endif /* HAVE_STRTOK */
+EXTERN int snprintf_append(char *str, int size, int pos, const char *fmt, ...);
 #if !defined(HAVE_STRERROR)
 EXTERN char *strerror (int err_no);
 #endif /* HAVE_STRERROR */

--- a/doc/whox.md
+++ b/doc/whox.md
@@ -1,0 +1,68 @@
+# WHOX
+## Introduction
+See https://ircv3.net/specs/extensions/whox
+
+## Standard fields
+| Field  | Description                                  | Hint           |
+| ------ |----------------------------------------------| -------------- |
+|t| the \<token\> specified by the client        ||
+|c| an arbitrary channel the client is joined to ||
+|u| username                                     ||
+|i| IP address                                   ||
+|h| hostname                                     ||
+|s| server name                                  ||
+|n| nickname                                     ||
+|f| WHO flags (away, server operator, etc)       ||
+|d| hop count (distance)                         ||
+|l| number of seconds the user has been idle for | Idle time of users on other servers is not available |
+|a| account name                                 |SASL account name or "0" if the user is not logged in|
+|o| channel op level                             |Always "n/a"|
+|r| realname                                     ||
+
+## Additional non-standard fields
+The following additional fields have been added:
+| Field  | Description   |
+| ------ | ------------- |
+| S      | return the SID|
+| U      | return the UID|
+
+
+## Examples
+Username/ident, IP address, hostname, nick
+
+    WHO #ircd %cihn
+    :dev.irc.it 354 test #ircd 92.74.191.157 dslb-092-074-191-157.092.074.pools.vodafone-ip.de test
+    :dev.irc.it 354 test #ircd 54.38.153.88 de.ircnet.com patrick_
+    :dev.irc.it 354 test #ircd 255.255.255.255 patrick.users.contempt.chat patrick
+    :dev.irc.it 315 test #ircd :End of WHO list.
+
+Nick and UID
+
+    WHO #ircd %cnU
+    :dev.irc.it 354 test #ircd test 380DAAAAB
+    :dev.irc.it 354 test #ircd patrick_ 380IAAADT
+    :dev.irc.it 354 test #ircd patrick 380IAAADL
+    :dev.irc.it 315 test #ircd :End of WHO list.
+
+SID only
+
+    WHO #ircd %cS
+    :dev.irc.it 354 test #ircd 380D
+    :dev.irc.it 354 test #ircd 380I
+    :dev.irc.it 354 test #ircd 380I
+    :dev.irc.it 315 test #ircd :End of WHO list.
+
+
+All information and token 123
+
+    WHO #ircd %tcuihsnfdlaorSU,123
+    :dev.irc.it 354 test 123 #ircd ~username 92.74.191.157 dslb-092-074-191-157.092.074.pools.vodafone-ip.de dev.irc.it test H 0 262 0 n/a 380D 380DAAAAB :realname
+    :dev.irc.it 354 test 123 #ircd ~patrick 54.38.153.88 de.ircnet.com nova.irc.it patrick_ H 1 0 0 n/a 380I 380IAAADS :email: patrick@ircnet.com
+    :dev.irc.it 354 test 123 #ircd ~patrick 255.255.255.255 patrick.users.contempt.chat nova.irc.it patrick H*@ 1 0 patrick n/a 380I 380IAAADL :Patrick
+    :dev.irc.it 315 test #ircd :End of WHO list.
+
+Legacy: Former 'o' flag which filters for opers is still working with or without WHOX fields
+
+    who #ircd o%cn 
+    :dev.irc.it 354 test #ircd patrick
+    :dev.irc.it 315 test #ircd :End of WHO list.

--- a/ircd/s_err.c
+++ b/ircd/s_err.c
@@ -386,7 +386,7 @@ char *	replies[] = {
 /* 351 RPL_VERSION */	":%s 351 %s %s.%s %s %s :%s",
 /* 352 RPL_WHOREPLY */	":%s 352 %s %s %s %s %s %s %s :%d %s %s",
 /* 353 RPL_NAMREPLY */	":%s 353 %s %s",
-/* 354 */ (char *)NULL,
+/* 354 RPL_WHOSPCRPL */ ":%s 354 %s",
 /* 355 */ (char *)NULL,
 /* 356 */ (char *)NULL,
 /* 357 */ (char *)NULL,

--- a/ircd/s_misc.c
+++ b/ircd/s_misc.c
@@ -196,14 +196,8 @@ char	*get_client_name(aClient *sptr, int showip)
 				(void)sprintf(nbuf, "%s[%.*s@%s]",
 					sptr->name, USERLEN,
 					(!(sptr->flags & FLAGS_GOTID)) ? "" :
-					sptr->auth, sptr->user ? sptr->user->sip :
-#ifdef INET6 
-					      inetntop(AF_INET6,
-						       (char *)&sptr->ip,
-						       ipv6string, sizeof(ipv6string))
-#else
-					      inetntoa((char *)&sptr->ip)
-#endif
+					sptr->auth,
+					get_client_ip(sptr)
 					);
 			else
 			    {
@@ -245,6 +239,22 @@ char	*get_client_host(aClient *cptr)
 			(!(cptr->flags & FLAGS_GOTID)) ? "" : cptr->auth,
 			HOSTLEN, cptr->user->sip);
 	return nbuf;
+}
+
+char	*get_client_ip(aClient *cptr)
+{
+	if (cptr->user)
+	{
+		return cptr->user->sip;
+	}
+	else
+	{
+#ifdef INET6
+		return inetntop(AF_INET6, (char *)&cptr->ip, ipv6string, sizeof(ipv6string));
+#else
+		return inetntoa((char *)&cptr->ip);
+#endif
+	}
 }
 
 /*

--- a/ircd/s_misc_ext.h
+++ b/ircd/s_misc_ext.h
@@ -42,6 +42,7 @@ EXTERN int check_registered (aClient *sptr);
 EXTERN int check_registered_service (aClient *sptr);
 EXTERN char *get_client_name (aClient *sptr, int showip);
 EXTERN char *get_client_host (aClient *cptr);
+EXTERN char *get_client_ip (aClient *cptr);
 EXTERN void get_sockhost (Reg aClient *cptr, Reg char *host);
 EXTERN char *my_name_for_link (char *name, Reg int count);
 EXTERN int mark_blind_servers (aClient *cptr, aClient *server);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1264,7 +1264,7 @@ int	m_server_estab(aClient *cptr, char *sid, char *versionbuf)
 					   acptr->name, acptr->user->uid,
 					   acptr->user->username,
 					   acptr->user->host,
-					   acptr->user->sip,
+					   get_client_ip(acptr),
 					   (*buf) ? buf : "+", acptr->info);
 		    }
 		else if (IsService(acptr) &&
@@ -2857,7 +2857,7 @@ int	m_etrace(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				IsAnOper(acptr) ? "Oper" : "User",
 				get_client_class(acptr),
 				acptr->name, acptr->user->username,
-				acptr->user->host, acptr->user->sip,
+				acptr->user->host, get_client_ip(acptr),
 #ifdef XLINE
 				acptr->user2, acptr->user3, 
 #else
@@ -2880,7 +2880,7 @@ int	m_etrace(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				IsAnOper(acptr) ? "Oper" : "User", 
 				get_client_class(acptr), 
 				acptr->name, acptr->user->username, 
-				acptr->user->host, acptr->user->sip,
+				acptr->user->host, get_client_ip(acptr),
 #ifdef XLINE
 				acptr->user2, acptr->user3, 
 #else
@@ -2916,7 +2916,7 @@ int	m_sidtrace(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			IsAnOper(acptr) ? "Oper" : "User", 
 			MyClient(acptr) ? get_client_class(acptr) : -1, 
 			acptr->name, acptr->user->username,
-			acptr->user->host, acptr->user->sip, 
+			acptr->user->host, get_client_ip(acptr),
 #ifdef XLINE
 			MyClient(acptr) ? acptr->user2 : "-",
 			MyClient(acptr) ? acptr->user3 : "-",

--- a/ircd/s_service.c
+++ b/ircd/s_service.c
@@ -180,7 +180,7 @@ static	void	sendnum_toone(aClient *cptr, int wants, aClient *sptr,
 			sptr->user->uid,
 			(wants & SERVICE_WANT_USER) ? sptr->user->username : ".",
 			(wants & SERVICE_WANT_USER) ? sptr->user->host : ".",
-			(wants & SERVICE_WANT_USER) ? sptr->user->sip : ".",
+			(wants & SERVICE_WANT_USER) ? get_client_ip(sptr) : ".",
 			(wants & (SERVICE_WANT_UMODE|SERVICE_WANT_OPER)) ? umode : "+",
 			(wants & SERVICE_WANT_USER) ? sptr->info : "");
 	else

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -814,7 +814,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 		sendto_one(acptr,
 				":%s UNICK %s %s %s %s %s %s :%s",
 				user->servp->sid, nick, user->uid,
-				user->username, user->host, user->sip,
+				user->username, user->host, get_client_ip(sptr),
 				(*buf) ? buf : "+", sptr->info);
 	}	/* for(my-leaf-servers) */
 #ifdef	USE_SERVICES

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1683,12 +1683,13 @@ int	m_notice(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 /*
 ** who_one
-**	sends one RPL_WHOREPLY to sptr concerning acptr & repchan
+**	sends one RPL_WHOREPLY or RPL_WHOSPCRPL to sptr concerning acptr & repchan
 */
 static	void	who_one(aClient *sptr, aClient *acptr, aChannel *repchan,
-		Link *lp)
+		Link *lp, struct who_opts *opts)
 {
 	char	status[5];
+	char *s;
 	int	i = 0;
 
 	if (acptr->user->flags & FLAGS_AWAY)
@@ -1707,18 +1708,58 @@ static	void	who_one(aClient *sptr, aClient *acptr, aChannel *repchan,
 			status[i++] = '+';
 	    }
 	status[i] = '\0';
-	sendto_one(sptr, replies[RPL_WHOREPLY], ME, BadTo(sptr->name),
-		   (repchan) ? (repchan->chname) : "*", acptr->user->username,
-		   acptr->user->host, acptr->user->server, acptr->name,
-		   status, acptr->hopcount, acptr->user->servp->sid, acptr->info);
-}
 
+	if((opts->flags & ~WHO_FLAG_OPERS_ONLY) != 0) {
+        char buf[BUFSIZE];
+        int len = snprintf(buf, BUFSIZE, replies[RPL_WHOSPCRPL], ME, BadTo(sptr->name));
+
+        if (opts->flags & WHO_FLAG_TOKEN)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", opts->token != NULL ? opts->token : "0");
+        if (opts->flags & WHO_FLAG_CHANNEL)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", (repchan) ? (repchan->chname) : "*");
+        if (opts->flags & WHO_FLAG_USER)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->username);
+        if (opts->flags & WHO_FLAG_IP)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", get_client_ip(acptr));
+        if (opts->flags & WHO_FLAG_HOST)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->host);
+        if (opts->flags & WHO_FLAG_SERVER)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->server);
+        if (opts->flags & WHO_FLAG_NICK)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->name);
+        if (opts->flags & WHO_FLAG_FLAGS)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", status);
+        if (opts->flags & WHO_FLAG_HOP)
+            len += snprintf_append(buf, BUFSIZE, len, " %d", acptr->hopcount);
+        if (opts->flags & WHO_FLAG_IDLE)
+            len += snprintf_append(buf, BUFSIZE, len, " %ld",
+                                   MyClient(acptr) ? (long)(timeofday - acptr->user->last): 0);
+        if (opts->flags & WHO_FLAG_ACCOUNT)
+			len += snprintf_append(buf, BUFSIZE, len, " 0");
+        if (opts->flags & WHO_FLAG_OP_LEVEL)
+            len += snprintf_append(buf, BUFSIZE, len, " n/a");
+        if (opts->flags & WHO_FLAG_SID)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->servp->sid);
+        if (opts->flags & WHO_FLAG_UID)
+            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->uid);
+        if (opts->flags & WHO_FLAG_INFO)
+            len += snprintf_append(buf, BUFSIZE, len, " :%s", acptr->info);
+
+        sendto_one(sptr, buf);
+    }
+	else {
+        sendto_one(sptr, replies[RPL_WHOREPLY], ME, BadTo(sptr->name),
+                   (repchan) ? (repchan->chname) : "*", acptr->user->username,
+                   acptr->user->host, acptr->user->server, acptr->name,
+                   status, acptr->hopcount, acptr->user->servp->sid, acptr->info);
+    }
+}
 
 /*
 ** who_channel
 **	lists all users on a given channel
 */
-static	void	who_channel(aClient *sptr, aChannel *chptr, int oper)
+static	void	who_channel(aClient *sptr, aChannel *chptr, struct who_opts *opts)
 {
 	Reg	Link	*lp;
 	int	member;
@@ -1730,7 +1771,7 @@ static	void	who_channel(aClient *sptr, aChannel *chptr, int oper)
 		{
 			for (lp = chptr->members; lp; lp = lp->next)
 			{
-				if (oper && !IsAnOper(lp->value.cptr))
+				if ((opts->flags & WHO_FLAG_OPERS_ONLY) && !IsAnOper(lp->value.cptr))
 				{
 					continue;
 				}
@@ -1738,13 +1779,13 @@ static	void	who_channel(aClient *sptr, aChannel *chptr, int oper)
 				{
 					continue;
 				}
-				who_one(sptr, lp->value.cptr, chptr, lp);
+				who_one(sptr, lp->value.cptr, chptr, lp, opts);
 			}
 		}
 	}
 	else if ((lp = find_user_link(chptr->members, sptr)))
 	{
-		who_one(sptr, lp->value.cptr, chptr, lp);
+		who_one(sptr, lp->value.cptr, chptr, lp, opts);
 	}
 }
 
@@ -1755,7 +1796,7 @@ static	void	who_channel(aClient *sptr, aChannel *chptr, int oper)
 **	
 **	Reduced CPU load - 05/2001
 */
-static	void	who_find(aClient *sptr, char *mask, int oper)
+static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 {
 	aChannel *chptr = NULL;
 	Link	*lp,*lp2;
@@ -1778,7 +1819,7 @@ static	void	who_find(aClient *sptr, char *mask, int oper)
 				continue;
 			}
 			
-			if (oper && !IsAnOper(acptr))
+			if ((opts->flags & WHO_FLAG_OPERS_ONLY) && !IsAnOper(acptr))
 			{
 				continue;
 			}
@@ -1794,7 +1835,7 @@ static	void	who_find(aClient *sptr, char *mask, int oper)
 			     match(mask, acptr->user->host) == 0 ||
 			     match(mask, acptr->user->server) == 0 ||
 			     match(mask, acptr->info) == 0)
-				who_one(sptr, acptr, chptr, NULL);
+				who_one(sptr, acptr, chptr, NULL, opts);
 		
 		}
 	}
@@ -1822,7 +1863,7 @@ static	void	who_find(aClient *sptr, char *mask, int oper)
 		}
 		
 		/* we wanted only opers */
-		if (oper && !IsAnOper(acptr))
+		if ((opts->flags & WHO_FLAG_OPERS_ONLY) && !IsAnOper(acptr))
 		{
 			continue;
 		}
@@ -1838,11 +1879,84 @@ static	void	who_find(aClient *sptr, char *mask, int oper)
 		     match(mask, acptr->user->host) == 0 ||
 		     match(mask, acptr->user->server) == 0 ||
 		     match(mask, acptr->info) == 0)
-			who_one(sptr, acptr, NULL, NULL);
+			who_one(sptr, acptr, NULL, NULL, opts);
 	}
 	
 }
 
+void parse_who_arg(char *arg, struct who_opts *opts)
+{
+    char *s;
+
+    // WHO <mask> o
+    if(*arg == 'o') {
+        opts->flags |= WHO_FLAG_OPERS_ONLY;
+    }
+
+    // WHOX
+    if((s = strchr(arg, '%')) != NULL) {
+        char buf[BUFSIZE];
+        s++;
+
+        for (; *s; s++) {
+            switch (*s) {
+                case 't' :
+                    opts->flags |= WHO_FLAG_TOKEN;
+                    break;
+                case 'c' :
+                    opts->flags |= WHO_FLAG_CHANNEL;
+                    break;
+                case 'u' :
+                    opts->flags |= WHO_FLAG_USER;
+                    break;
+                case 'i' :
+                    opts->flags |= WHO_FLAG_IP;
+                    break;
+                case 'h' :
+                    opts->flags |= WHO_FLAG_HOST;
+                    break;
+                case 's' :
+                    opts->flags |= WHO_FLAG_SERVER;
+                    break;
+                case 'n' :
+                    opts->flags |= WHO_FLAG_NICK;
+                    break;
+                case 'f' :
+                    opts->flags |= WHO_FLAG_FLAGS;
+                    break;
+                case 'd' :
+                    opts->flags |= WHO_FLAG_HOP;
+                    break;
+                case 'l' :
+                    opts->flags |= WHO_FLAG_IDLE;
+                    break;
+                case 'a' :
+                    opts->flags |= WHO_FLAG_ACCOUNT;
+                    break;
+                case 'o' :
+                    opts->flags |= WHO_FLAG_OP_LEVEL;
+                    break;
+                case 'S' :
+                    opts->flags |= WHO_FLAG_SID;
+                    break;
+                case 'U' :
+                    opts->flags |= WHO_FLAG_UID;
+                    break;
+                case 'r' :
+                    opts->flags |= WHO_FLAG_INFO;
+                    break;
+                case ',':
+                    s++;
+                    int token_len = strlen(s);
+                    if (*s && token_len <= 3)
+                        opts->token = s;
+                    s += token_len;
+                    s--;
+                    break;
+            }
+        }
+    }
+}
 
 /*
 ** m_who
@@ -1853,16 +1967,22 @@ static	void	who_find(aClient *sptr, char *mask, int oper)
 int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 {
 	aChannel *chptr;
-	int	oper = parc > 2 ? (*parv[2] == 'o' ): 0; /* Show OPERS only */
-	int	penalty = 0;
-	char	*p, *mask, *channame;
+	int penalty = 0;
+    char *p, *mask, *channame;
+    struct who_opts opts;
+    opts.flags = 0;
+    opts.token = NULL;
 
 	if (parc < 2)
 	{
-		who_find(sptr, NULL, oper);
+		who_find(sptr, NULL, &opts);
 		sendto_one(sptr, replies[RPL_ENDOFWHO], ME, BadTo(parv[0]), "*");
 		/* it was very CPU intensive */
 		return MAXPENALTY;
+	}
+
+	if(parc > 2) {
+        parse_who_arg(parv[2], &opts);
 	}
 
 	/* get rid of duplicates */
@@ -1921,7 +2041,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			chptr = find_channel(channame, NULL);
 			if (chptr)
 			{
-				who_channel(sptr, chptr, oper);
+				who_channel(sptr, chptr, &opts);
 			}
 			else
 			{
@@ -1951,7 +2071,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			if (acptr)
 			{
 				/* We found client, so send WHO for it */
-				who_one(sptr, acptr, NULL, NULL);
+				who_one(sptr, acptr, NULL, NULL, &opts);
 			}
 			else
 			{
@@ -1963,7 +2083,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				/* simplify mask */
 				(void)collapse(mask);
 
-				who_find(sptr, mask, oper);
+				who_find(sptr, mask, &opts);
 				penalty += MAXPENALTY;
 			}
 		}

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1709,50 +1709,52 @@ static	void	who_one(aClient *sptr, aClient *acptr, aChannel *repchan,
 	    }
 	status[i] = '\0';
 
-	if((opts->flags & ~WHO_FLAG_OPERS_ONLY) != 0) {
-        char buf[BUFSIZE];
-        int len = snprintf(buf, BUFSIZE, replies[RPL_WHOSPCRPL], ME, BadTo(sptr->name));
+	if((opts->flags & ~WHO_FLAG_OPERS_ONLY) != 0)
+	{
+		char buf[BUFSIZE];
+		int len = snprintf(buf, BUFSIZE, replies[RPL_WHOSPCRPL], ME, BadTo(sptr->name));
 
-        if (opts->flags & WHO_FLAG_TOKEN)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", opts->token != NULL ? opts->token : "0");
-        if (opts->flags & WHO_FLAG_CHANNEL)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", (repchan) ? (repchan->chname) : "*");
-        if (opts->flags & WHO_FLAG_USER)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->username);
-        if (opts->flags & WHO_FLAG_IP)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", get_client_ip(acptr));
-        if (opts->flags & WHO_FLAG_HOST)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->host);
-        if (opts->flags & WHO_FLAG_SERVER)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->server);
-        if (opts->flags & WHO_FLAG_NICK)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->name);
-        if (opts->flags & WHO_FLAG_FLAGS)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", status);
-        if (opts->flags & WHO_FLAG_HOP)
-            len += snprintf_append(buf, BUFSIZE, len, " %d", acptr->hopcount);
-        if (opts->flags & WHO_FLAG_IDLE)
-            len += snprintf_append(buf, BUFSIZE, len, " %ld",
-                                   MyClient(acptr) ? (long)(timeofday - acptr->user->last): 0);
-        if (opts->flags & WHO_FLAG_ACCOUNT)
+		if (opts->flags & WHO_FLAG_TOKEN)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", opts->token != NULL ? opts->token : "0");
+		if (opts->flags & WHO_FLAG_CHANNEL)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", (repchan) ? (repchan->chname) : "*");
+		if (opts->flags & WHO_FLAG_USER)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->username);
+		if (opts->flags & WHO_FLAG_IP)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", get_client_ip(acptr));
+		if (opts->flags & WHO_FLAG_HOST)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->host);
+		if (opts->flags & WHO_FLAG_SERVER)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->server);
+		if (opts->flags & WHO_FLAG_NICK)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->name);
+		if (opts->flags & WHO_FLAG_FLAGS)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", status);
+		if (opts->flags & WHO_FLAG_HOP)
+			len += snprintf_append(buf, BUFSIZE, len, " %d", acptr->hopcount);
+		if (opts->flags & WHO_FLAG_IDLE)
+			len += snprintf_append(buf, BUFSIZE, len, " %ld",
+								   MyClient(acptr) ? (long) (timeofday - acptr->user->last) : 0);
+		if (opts->flags & WHO_FLAG_ACCOUNT)
 			len += snprintf_append(buf, BUFSIZE, len, " 0");
-        if (opts->flags & WHO_FLAG_OP_LEVEL)
-            len += snprintf_append(buf, BUFSIZE, len, " n/a");
-        if (opts->flags & WHO_FLAG_SID)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->servp->sid);
-        if (opts->flags & WHO_FLAG_UID)
-            len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->uid);
-        if (opts->flags & WHO_FLAG_INFO)
-            len += snprintf_append(buf, BUFSIZE, len, " :%s", acptr->info);
+		if (opts->flags & WHO_FLAG_OP_LEVEL)
+			len += snprintf_append(buf, BUFSIZE, len, " n/a");
+		if (opts->flags & WHO_FLAG_SID)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->servp->sid);
+		if (opts->flags & WHO_FLAG_UID)
+			len += snprintf_append(buf, BUFSIZE, len, " %s", acptr->user->uid);
+		if (opts->flags & WHO_FLAG_INFO)
+			len += snprintf_append(buf, BUFSIZE, len, " :%s", acptr->info);
 
-        sendto_one(sptr, buf);
-    }
-	else {
-        sendto_one(sptr, replies[RPL_WHOREPLY], ME, BadTo(sptr->name),
-                   (repchan) ? (repchan->chname) : "*", acptr->user->username,
-                   acptr->user->host, acptr->user->server, acptr->name,
-                   status, acptr->hopcount, acptr->user->servp->sid, acptr->info);
-    }
+		sendto_one(sptr, buf);
+	}
+	else
+	{
+		sendto_one(sptr, replies[RPL_WHOREPLY], ME, BadTo(sptr->name),
+				   (repchan) ? (repchan->chname) : "*", acptr->user->username,
+				   acptr->user->host, acptr->user->server, acptr->name,
+				   status, acptr->hopcount, acptr->user->servp->sid, acptr->info);
+	}
 }
 
 /*
@@ -1884,78 +1886,81 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 	
 }
 
-void parse_who_arg(char *arg, struct who_opts *opts)
-{
-    char *s;
+void parse_who_arg(char *arg, struct who_opts *opts) {
+	char *s;
 
-    // WHO <mask> o
-    if(*arg == 'o') {
-        opts->flags |= WHO_FLAG_OPERS_ONLY;
-    }
+	// WHO <mask> o
+	if (*arg == 'o')
+	{
+		opts->flags |= WHO_FLAG_OPERS_ONLY;
+	}
 
-    // WHOX
-    if((s = strchr(arg, '%')) != NULL) {
-        char buf[BUFSIZE];
-        s++;
+	// WHOX
+	if ((s = strchr(arg, '%')) != NULL)
+	{
+		char buf[BUFSIZE];
+		s++;
 
-        for (; *s; s++) {
-            switch (*s) {
-                case 't' :
-                    opts->flags |= WHO_FLAG_TOKEN;
-                    break;
-                case 'c' :
-                    opts->flags |= WHO_FLAG_CHANNEL;
-                    break;
-                case 'u' :
-                    opts->flags |= WHO_FLAG_USER;
-                    break;
-                case 'i' :
-                    opts->flags |= WHO_FLAG_IP;
-                    break;
-                case 'h' :
-                    opts->flags |= WHO_FLAG_HOST;
-                    break;
-                case 's' :
-                    opts->flags |= WHO_FLAG_SERVER;
-                    break;
-                case 'n' :
-                    opts->flags |= WHO_FLAG_NICK;
-                    break;
-                case 'f' :
-                    opts->flags |= WHO_FLAG_FLAGS;
-                    break;
-                case 'd' :
-                    opts->flags |= WHO_FLAG_HOP;
-                    break;
-                case 'l' :
-                    opts->flags |= WHO_FLAG_IDLE;
-                    break;
-                case 'a' :
-                    opts->flags |= WHO_FLAG_ACCOUNT;
-                    break;
-                case 'o' :
-                    opts->flags |= WHO_FLAG_OP_LEVEL;
-                    break;
-                case 'S' :
-                    opts->flags |= WHO_FLAG_SID;
-                    break;
-                case 'U' :
-                    opts->flags |= WHO_FLAG_UID;
-                    break;
-                case 'r' :
-                    opts->flags |= WHO_FLAG_INFO;
-                    break;
-                case ',':
-                    s++;
-                    int token_len = strlen(s);
-                    if (*s && token_len <= 3)
-                        opts->token = s;
-                    s += token_len;
-                    s--;
-                    break;
-            }
-        }
-    }
+		for (; *s; s++)
+		{
+			switch (*s)
+			{
+				case 't' :
+					opts->flags |= WHO_FLAG_TOKEN;
+					break;
+				case 'c' :
+					opts->flags |= WHO_FLAG_CHANNEL;
+					break;
+				case 'u' :
+					opts->flags |= WHO_FLAG_USER;
+					break;
+				case 'i' :
+					opts->flags |= WHO_FLAG_IP;
+					break;
+				case 'h' :
+					opts->flags |= WHO_FLAG_HOST;
+					break;
+				case 's' :
+					opts->flags |= WHO_FLAG_SERVER;
+					break;
+				case 'n' :
+					opts->flags |= WHO_FLAG_NICK;
+					break;
+				case 'f' :
+					opts->flags |= WHO_FLAG_FLAGS;
+					break;
+				case 'd' :
+					opts->flags |= WHO_FLAG_HOP;
+					break;
+				case 'l' :
+					opts->flags |= WHO_FLAG_IDLE;
+					break;
+				case 'a' :
+					opts->flags |= WHO_FLAG_ACCOUNT;
+					break;
+				case 'o' :
+					opts->flags |= WHO_FLAG_OP_LEVEL;
+					break;
+				case 'S' :
+					opts->flags |= WHO_FLAG_SID;
+					break;
+				case 'U' :
+					opts->flags |= WHO_FLAG_UID;
+					break;
+				case 'r' :
+					opts->flags |= WHO_FLAG_INFO;
+					break;
+				case ',':
+					s++;
+					int token_len = strlen(s);
+					if (*s && token_len <= 3)
+						opts->token = s;
+					s += token_len;
+					s--;
+					break;
+			}
+		}
+	}
 }
 
 /*
@@ -1968,10 +1973,10 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 {
 	aChannel *chptr;
 	int penalty = 0;
-    char *p, *mask, *channame;
-    struct who_opts opts;
-    opts.flags = 0;
-    opts.token = NULL;
+	char *p, *mask, *channame;
+	struct who_opts opts;
+	opts.flags = 0;
+	opts.token = NULL;
 
 	if (parc < 2)
 	{
@@ -1981,8 +1986,9 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		return MAXPENALTY;
 	}
 
-	if(parc > 2) {
-        parse_who_arg(parv[2], &opts);
+	if(parc > 2)
+	{
+		parse_who_arg(parv[2], &opts);
 	}
 
 	/* get rid of duplicates */


### PR DESCRIPTION
# WHOX
## Introduction
See https://ircv3.net/specs/extensions/whox

## Standard fields
| Field  | Description                                  | Hint           |
| ------ |----------------------------------------------| -------------- |
|t| the \<token\> specified by the client        ||
|c| an arbitrary channel the client is joined to ||
|u| username                                     ||
|i| IP address                                   ||
|h| hostname                                     ||
|s| server name                                  ||
|n| nickname                                     ||
|f| WHO flags (away, server operator, etc)       ||
|d| hop count (distance)                         ||
|l| number of seconds the user has been idle for | Idle time of users on other servers is not available |
|a| account name                                 |SASL account name or "0" if the user is not logged in|
|o| channel op level                             |Always "n/a"|
|r| realname                                     ||

## Additional non-standard fields
The following additional fields have been added:
| Field  | Description   |
| ------ | ------------- |
| S      | return the SID|
| U      | return the UID|


## Examples
Username/ident, IP address, hostname, nick

    WHO #ircd %cihn
    :dev.irc.it 354 test #ircd 92.74.191.157 dslb-092-074-191-157.092.074.pools.vodafone-ip.de test
    :dev.irc.it 354 test #ircd 54.38.153.88 de.ircnet.com patrick_
    :dev.irc.it 354 test #ircd 255.255.255.255 patrick.users.contempt.chat patrick
    :dev.irc.it 315 test #ircd :End of WHO list.

Nick and UID

    WHO #ircd %cnU
    :dev.irc.it 354 test #ircd test 380DAAAAB
    :dev.irc.it 354 test #ircd patrick_ 380IAAADT
    :dev.irc.it 354 test #ircd patrick 380IAAADL
    :dev.irc.it 315 test #ircd :End of WHO list.

SID only

    WHO #ircd %cS
    :dev.irc.it 354 test #ircd 380D
    :dev.irc.it 354 test #ircd 380I
    :dev.irc.it 354 test #ircd 380I
    :dev.irc.it 315 test #ircd :End of WHO list.


All information and token 123

    WHO #ircd %tcuihsnfdlaorSU,123
    :dev.irc.it 354 test 123 #ircd ~username 92.74.191.157 dslb-092-074-191-157.092.074.pools.vodafone-ip.de dev.irc.it test H 0 262 0 n/a 380D 380DAAAAB :realname
    :dev.irc.it 354 test 123 #ircd ~patrick 54.38.153.88 de.ircnet.com nova.irc.it patrick_ H 1 0 0 n/a 380I 380IAAADS :email: patrick@ircnet.com
    :dev.irc.it 354 test 123 #ircd ~patrick 255.255.255.255 patrick.users.contempt.chat nova.irc.it patrick H*@ 1 0 patrick n/a 380I 380IAAADL :Patrick
    :dev.irc.it 315 test #ircd :End of WHO list.

Legacy: Former 'o' flag which filters for opers is still working with or without WHOX fields

    who #ircd o%cn 
    :dev.irc.it 354 test #ircd patrick
    :dev.irc.it 315 test #ircd :End of WHO list.