### PR TITLE
Extended P-Line for source IP address used in ident/auth requests

### DIFF
--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -583,6 +583,18 @@ void	start_auth(aClient *cptr)
 	   from query socket -- jrg */
 	(void)getsockname(cptr->fd, (struct sockaddr *)&us, &ulen);
 	us.SIN_FAMILY = AFINET;
+
+	// Check if a source IP has been set in P-Line (usually if an SSL proxy is used)
+	if (cptr->acpt->confs && IsConfTLS(cptr->acpt->confs->value.aconf)
+		&& !BadPtr(cptr->acpt->confs->value.aconf->source_ip))
+	{
+# ifdef INET6
+		inet_pton(AF_INET6, cptr->acpt->confs->value.aconf->source_ip, us.sin6_addr.s6_addr);
+# else
+		us.sin_addr.s_addr = inetaddr(cptr->acpt->confs->value.aconf->source_ip);
+# endif
+	}
+
 # if defined(USE_IAUTH)
 	if (adfd >= 0)
 	    {

--- a/ircd/s_auth.c
+++ b/ircd/s_auth.c
@@ -589,7 +589,7 @@ void	start_auth(aClient *cptr)
 		&& !BadPtr(cptr->acpt->confs->value.aconf->source_ip))
 	{
 # ifdef INET6
-		inet_pton(AF_INET6, cptr->acpt->confs->value.aconf->source_ip, us.sin6_addr.s6_addr);
+		inetpton(AF_INET6, cptr->acpt->confs->value.aconf->source_ip, us.sin6_addr.s6_addr);
 # else
 		us.sin_addr.s_addr = inetaddr(cptr->acpt->confs->value.aconf->source_ip);
 # endif

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1811,7 +1811,10 @@ int 	initconf(int opt)
 					iline_flags_parse(tmp3) :
 					pline_flags_parse(tmp3));
 			}
-
+			if(aconf->status & CONF_LISTEN_PORT && tmp4 && *tmp4)
+			{
+				DupString(aconf->source_ip, tmp4);
+			}
 			/* trying to find exact conf line in already existing
 			 * conf, so we don't delete old one, just update it */
 			if (


### PR DESCRIPTION
When you create a TLS/SSL tunnel with stunnel or haproxy/mmproxy the ircd does not know the IP address you connected to. Because of this iauth tries to bind to the wrong IP address.

stunnel:
```
[ircd_6697]
accept  = 45.141.0.18:6697
connect = 127.0.0.1:6697
cert = ..
transparent = source
```

If a user connects to 45.141.0.18:6697 he will be tunneled to 127.0.0.1:6697. The problem is iauth will bind to 127.0.0.1 to do the ident check which will fail.

I also could not get it working with `transparent = both`.

Solution:
In P-Line we can make the auth source address definable:
```P|127.0.0.1|||6679||T|45.141.0.18|```