### PR TITLE
Adding checking SIDTRACE for O-lines in chkconf

### DIFF
--- a/ircd/chkconf.c
+++ b/ircd/chkconf.c
@@ -587,6 +587,9 @@ static	aConfItem 	*initconf(void)
 				case 'p':
 				case 'P':
 				case 't':
+#ifdef ENABLE_SIDTRACE
+				case 'v':
+#endif
 					break;
 				case ' ':
 				case '\t':


### PR DESCRIPTION
chkconf gives a warning about a unknown flag for O-lines while it is configured
This should fix it