### PR TITLE
If zip is not available, but is configured, give an error instead of …

### DIFF
--- a/support/config.h.dist
+++ b/support/config.h.dist
@@ -886,8 +886,8 @@
 ** Make sure that if zlib isn't found, or you don't want to use it, that you
 ** don't define ZIP_LINKS
 */
-#ifndef	USE_ZLIB
-#undef	ZIP_LINKS
+#if	!defined(USE_ZLIB) && defined(ZIP_LINKS)
+# error ZIP_LINKS defined but no ZLIB available
 #endif
 
 #if defined(TIMEDKLINES)


### PR DESCRIPTION
…a silent disable