### PR TITLE
Give chkconf option to use an other location to check conf.conf then …

### DIFF
--- a/ircd/chkconf.c
+++ b/ircd/chkconf.c
@@ -73,6 +73,7 @@ static	int	checkSID(char *, int);
 static	int	numclasses = 0, *classarr = (int *)NULL, debugflag = 0;
 static	char	nullfield[] = "";
 static	char	maxsendq[12];
+char * configdir = IRCDCONF_DIR;
 
 #define	SHOWSTR(x)	((x) ? (x) : "*")
 
@@ -90,6 +91,7 @@ int	main(int argc, char *argv[])
 			"includes and/or M4)\n");
 		(void)printf("\t-d[#]\tthe bigger number, the more verbose "
 			"chkconf is in its checks\n");
+		(void)printf("\t-c\tUse folder instead of %s\n", IRCDCONF_DIR);
 		(void)printf("\tDefault ircd.conf = %s\n", IRCDCONF_PATH);
 		exit(0);
 	}
@@ -108,6 +110,13 @@ int	main(int argc, char *argv[])
 		showflag = 1;
 		argc--;
 		argv++;
+	}
+	if (argc > 2 && !strncmp(argv[1], "-c", 2))
+	{
+		configdir = argv[2];
+		argc-=2;
+		argv+=2;
+		config_set_ircdconf_dir(configdir);
 	}
 	if (argc > 1)
 		configfile = argv[1];
@@ -232,7 +241,7 @@ static	void	showconf(void)
 #if defined(CONFIG_DIRECTIVE_INCLUDE)
 	if (debugflag)
 	{
-		etclen = strlen(IRCDCONF_DIR);
+		etclen = strlen(configdir);
 	}
 	fdn = fdopen(fd, "r");
 	p2 = config_read(fdn, 0, new_config_file(configfile, NULL, 0));
@@ -240,7 +249,7 @@ static	void	showconf(void)
 	{
 		if (debugflag)
 			printf("%s:%d:", p->file->filename +
-				(strncmp(p->file->filename, IRCDCONF_DIR,
+				(strncmp(p->file->filename, configdir,
 				etclen) == 0 ? etclen : 0), p->linenum);
 		printf("%s\n", p->line);
 	}

--- a/ircd/config_read.c
+++ b/ircd/config_read.c
@@ -44,11 +44,14 @@ struct Config
 	aConfig *next;
 };
 
+char * config_ircdconf_dir = IRCDCONF_DIR;
+
 #ifdef CONFIG_DIRECTIVE_INCLUDE
 static aConfig	*config_read(FILE *, int, aFile *);
 static void	config_free(aConfig *);
 aFile	*new_config_file(char *, aFile *, int);
 void	config_error(int, aFile *, int, char *, ...);
+static void	config_set_ircdconf_dir(char *);
 #else
 void	config_error(int, char *, int, char *, ...);
 #endif
@@ -60,7 +63,7 @@ void	config_error(int, char *, int, char *, ...);
 ** #include "filename"
 ** # must be first char on the line, word include, one space, then ",
 ** filename and another " must be the last char on the line.
-** If filename does not start with slash, it's loaded from IRCDCONF_DIR.
+** If filename does not start with slash, it's loaded from config_ircdconf_dir.
 */
 
 /* read from supplied fd, putting line by line onto aConfig struct.
@@ -135,7 +138,7 @@ aConfig *config_read(FILE *fd, int depth, aFile *curfile)
 			if (*start != '/')
 			{
 				filep += snprintf(file, FILEMAX,
-					"%s", IRCDCONF_DIR);
+					"%s", config_ircdconf_dir);
 			}
 			if ((end - start) + (filep - file) >= FILEMAX)
 			{
@@ -158,6 +161,7 @@ aConfig *config_read(FILE *fd, int depth, aFile *curfile)
 					goto eatline;
 				}
 			}
+
 			if ((fdn = fopen(file, "r")) == NULL)
 			{
 				config_error(CF_ERR, curfile, linenum,
@@ -258,6 +262,24 @@ aFile *new_config_file(char *filename, aFile *parent, int fnr)
         }
         return tmp;
 }
+
+static void	config_set_ircdconf_dir(char * configdir)
+{
+	size_t len = strlen(configdir);
+	if (configdir[len - 1] != '/') {
+		// Allocate memory for new string with extra '/' and null-terminator
+		char *temp = malloc(len + 2);
+		if (temp == NULL) {
+			perror("malloc");
+			return 1;
+		}
+		strcpy(temp, configdir);
+		temp[len] = '/';
+		temp[len + 1] = '\0';
+		configdir = temp;
+	}
+	config_ircdconf_dir = configdir;
+}
 #endif /* CONFIG_DIRECTIVE_INCLUDE */
 
 #ifdef CONFIG_DIRECTIVE_INCLUDE
@@ -276,7 +298,7 @@ void config_error(int level, char *filename, int line, char *pattern, ...)
 
 	if (!etclen)
 	{
-		etclen = strlen(IRCDCONF_DIR);
+		etclen = strlen(config_ircdconf_dir);
 	}
 
 	va_start(va, pattern);
@@ -285,7 +307,7 @@ void config_error(int level, char *filename, int line, char *pattern, ...)
 
 	/* no need to show full path, if the same dir */
 	filep = filename;
-	if (0 == strncmp(filename, IRCDCONF_DIR, etclen))
+	if (0 == strncmp(filename, config_ircdconf_dir, etclen))
 		filep += etclen;
 #ifdef CHKCONF_COMPILE
 	if (level == CF_NONE)
@@ -300,7 +322,7 @@ void config_error(int level, char *filename, int line, char *pattern, ...)
 		while ((curF && curF->parent))
 		{
 			filep = curF->parent->filename;
-			if (0 == strncmp(filep, IRCDCONF_DIR, etclen))
+			if (0 == strncmp(filep, config_ircdconf_dir, etclen))
 				filep += etclen;
 			fprintf(stderr, "\tincluded in %s:%d\n",
 				filep, curF->includeline);


### PR DESCRIPTION
This should make this working

chkconf -d3 -s -c ~/ircd-config/ircnet ~/ircd-config/ircnet/ircd.conf 

and no ~/ircd-config is where the code would look at if you don't give a path
with `#include ` validating the config only works when it is on the right place, now you can test it in any dir

TODO:
testing withing include and with m4 