### PR TITLE
[2.12.0] Validate spoofed hostname sent by service

### DIFF
--- a/doc/sasl.md
+++ b/doc/sasl.md
@@ -4,7 +4,7 @@ This implementation is based on the documentation from Mantas Mikulėnas. Read *
 The following things are different:
 * logout is not supported
 * abortion of authentication is not supported, the user has to disable SASL explicitly at his IRC client if he wants to connect without authentication
-* the L-message contains the cloak (`L <loginName> <cloak>`) and the ircd sets it after successful authentication
+* the L-message contains the cloak (`L <loginName> :<cloak>`) and the ircd sets it after successful authentication
 * the H-message contains a hostmask (`H <nick>[[ident]@ip]`)
 * additional N-message to allow the SASL service to send a NOTICE to a user (`N :<notice>`)
 * additional K-message to allow the SASL service to disconnect a user before registration (K :<reason>`), e.g. if he fails to log in too often
@@ -38,7 +38,7 @@ You need to set up at least one service with the flags SERVICE_WANT_SASL and SER
     // The server forwards the message to the SASL service
     [Server -> Service] :000B SASL 000BAAAAD SASLService@irc1.localhost C dXNlcjEAdXNlcjEAdXNlcjEtcGFzc3dvcmQxMjM=
     // The service validates the credentials and sends success messages including the cloaked hostname
-    [Service -> Server] ENCAP 000B SASL 000BAAAAD * L user1 spoof1.ircnet.com
+    [Service -> Server] ENCAP 000B SASL 000BAAAAD * L user1 :spoof1.ircnet.com
     [Service -> Server] ENCAP 000B SASL 000BAAAAD * D S
     // The server sets the cloaked hostname and sends a success message to the client
     [Server -> User]    :irc1.localhost 900 patrick :You are now logged in as user1.

--- a/ircd/res.c
+++ b/ircd/res.c
@@ -1845,7 +1845,7 @@ u_long	cres_mem(aClient *sptr, char *nick)
 }
 
 
-int	bad_hostname(char *name, int len)
+int bad_hostname(char *name, int len)
 {
 	char	*s, c;
 

--- a/ircd/res.c
+++ b/ircd/res.c
@@ -54,7 +54,6 @@ static	ResRQ	*find_id (int);
 static	int	hash_number (unsigned char *);
 static	void	update_list (ResRQ *, aCache *);
 static	int	hash_name (char *);
-static	int	bad_hostname (char *, int);
 
 static	struct cacheinfo {
 	int	ca_adds;
@@ -1846,7 +1845,7 @@ u_long	cres_mem(aClient *sptr, char *nick)
 }
 
 
-static	int	bad_hostname(char *name, int len)
+int	bad_hostname(char *name, int len)
 {
 	char	*s, c;
 

--- a/ircd/res_ext.h
+++ b/ircd/res_ext.h
@@ -28,17 +28,17 @@
 #else /* RES_C */
 #define EXTERN
 #endif /* RES_C */
-extern int init_resolver (int op);
-EXTERN time_t timeout_query_list (time_t now);
-EXTERN void del_queries (char *cp);
-EXTERN struct hostent *gethost_byname (char *name, Link *lp);
-EXTERN struct hostent *gethost_byname_type (char *name, Link *lp, 
-						int type);
-EXTERN struct hostent *gethost_byaddr (char *addr, Link *lp);
-EXTERN struct hostent *get_res (char *lp);
-EXTERN time_t expire_cache (time_t now);
+extern int init_resolver(int op);
+EXTERN time_t timeout_query_list(time_t now);
+EXTERN void del_queries(char *cp);
+EXTERN struct hostent *gethost_byname(char *name, Link *lp);
+EXTERN struct hostent *gethost_byname_type(char *name, Link *lp,
+										   int type);
+EXTERN struct hostent *gethost_byaddr(char *addr, Link *lp);
+EXTERN struct hostent *get_res(char *lp);
+EXTERN time_t expire_cache(time_t now);
 EXTERN void flush_cache(void);
-EXTERN int m_dns (aClient *cptr, aClient *sptr, int parc, char *parv[]);
-EXTERN u_long cres_mem (aClient *sptr, char *nick);
+EXTERN int m_dns(aClient *cptr, aClient *sptr, int parc, char *parv[]);
+EXTERN u_long cres_mem(aClient *sptr, char *nick);
 EXTERN int bad_hostname(char *name, int len);
 #undef EXTERN

--- a/ircd/res_ext.h
+++ b/ircd/res_ext.h
@@ -40,4 +40,5 @@ EXTERN time_t expire_cache (time_t now);
 EXTERN void flush_cache(void);
 EXTERN int m_dns (aClient *cptr, aClient *sptr, int parc, char *parv[]);
 EXTERN u_long cres_mem (aClient *sptr, char *nick);
+EXTERN int bad_hostname (char *name, int len);
 #undef EXTERN

--- a/ircd/res_ext.h
+++ b/ircd/res_ext.h
@@ -40,5 +40,5 @@ EXTERN time_t expire_cache (time_t now);
 EXTERN void flush_cache(void);
 EXTERN int m_dns (aClient *cptr, aClient *sptr, int parc, char *parv[]);
 EXTERN u_long cres_mem (aClient *sptr, char *nick);
-EXTERN int bad_hostname (char *name, int len);
+EXTERN int bad_hostname(char *name, int len);
 #undef EXTERN

--- a/ircd/s_sasl.c
+++ b/ircd/s_sasl.c
@@ -147,11 +147,23 @@ void m_sasl_service(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	else if (*parv[3] == 'L')
 	{
 		// Login
-		acptr->sasl_user = mystrdup(parv[4]);
 		if (parc >= 6) {
-			// Store spoofed hostname. It will finally be set by attach_Iline().
-			acptr->spoof_tmp = mystrdup(parv[5]);
+			if (bad_hostname(parv[5], strlen(parv[5])))
+			{
+				char comment[BUFSIZE];
+				sendto_flag(SCH_ERROR, "Received bad hostname %s from %s", parv[5], acptr->sasl_service->name);
+				acptr->exitc = EXITC_SASL_REQUIRED;
+				snprintf(comment, BUFSIZE, "Bad hostname (%s)", parv[5]);
+				exit_client(acptr, acptr, &me, comment);
+				return;
+			}
+			else
+			{
+				// Store spoofed hostname. It will finally be set by attach_Iline().
+				acptr->spoof_tmp = mystrdup(parv[5]);
+			}
 		}
+		acptr->sasl_user = mystrdup(parv[4]);
 		sendto_one(acptr, replies[RPL_LOGGEDIN], me.name, BadTo(acptr->name), BadTo(acptr->name),
 				   acptr->user ? acptr->user->username : "unknown",
 				   acptr->spoof_tmp ? acptr->spoof_tmp : acptr->sockhost,

--- a/ircd/s_sasl.c
+++ b/ircd/s_sasl.c
@@ -147,7 +147,8 @@ void m_sasl_service(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	else if (*parv[3] == 'L')
 	{
 		// Login
-		if (parc == 6) {
+		if (parc == 6)
+		{
 			if (bad_hostname(parv[5], strlen(parv[5])))
 			{
 				char comment[BUFSIZE];

--- a/ircd/s_sasl.c
+++ b/ircd/s_sasl.c
@@ -147,7 +147,7 @@ void m_sasl_service(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	else if (*parv[3] == 'L')
 	{
 		// Login
-		if (parc >= 6) {
+		if (parc == 6) {
 			if (bad_hostname(parv[5], strlen(parv[5])))
 			{
 				char comment[BUFSIZE];


### PR DESCRIPTION
Validates the spoofed hostname sent by SASL service. If it is not valid the user will be disconnected because he should not be signed on with his real hostname.

```
20:25 !irc.localhost Received bad hostname *.ircnet.com from SASLService@irc.localhost
20:28 !irc.localhost Received bad hostname spoof\.ircnet.com from SASLService@irc.localhost
..
20:30 !irc.localhost Received bad hostname -spoof.ircnet.com from SASLService@irc.localhost
20:30 -!- ERROR Closing Link: [unknown@127.0.0.1] (Bad hostname (-spoof3.ircnet.com))
```

PS: Clang-format is OK for the new code.
