### PR TITLE
Y-Line limits for SASL based on hostname, not IP

### DIFF
--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -950,7 +950,7 @@ int	attach_conf(aClient *cptr, aConfItem *aconf)
 		if (ConfMaxHLocal(aconf) > 0 || ConfMaxUHLocal(aconf) > 0 ||
 		    ConfMaxHGlobal(aconf) > 0 || ConfMaxUHGlobal(aconf) > 0 )
 		{
-			if(IsSASLAuthed(cptr) && cptr->spoof_tmp != NULL)
+			if (IsSASLAuthed(cptr) && cptr->spoof_tmp != NULL)
 			{
 				/*
 				 * Because all cloaked connections have the same IP address (SPOOF_IP),


### PR DESCRIPTION
Because all cloaked connections have the IP address `255.255.255.255`, we have to use the cloaked hostname to check the Y-line limits (instead of IP or sockhost).

Originally from mh 2020-06-25


PS: We might add a better way for SASL in the next weeks, e.g. to allow "3 connections per account locally" by adding a new Y-Line field. But this change is needed too to get the normal Y-lines working.