### PR TITLE
refactored user->sip

### DIFF
--- a/common/struct_def.h
+++ b/common/struct_def.h
@@ -471,15 +471,13 @@ struct	User	{
 	aClient	*bcptr;
 	char	username[USERLEN+1];
 	char	host[HOSTLEN+1];
+	char	*sip;		/* IP as string */
 	char	*server;
 	u_int	hhashv;		/* hostname hash value */
 	u_int	iphashv;	/* IP hash value */
 	struct User *hhnext;	/* next entry in hostname hash */
 	struct User *iphnext;	/* next entry in IP hash */
 				/* sip MUST be the last in this struct!!! */
-	char	sip[1];		/* ip as a string, big enough for ipv6
-				 * allocated to real size in make_user */
-
 };
 
 struct	Server	{

--- a/ircd/ircd.c
+++ b/ircd/ircd.c
@@ -719,7 +719,7 @@ static	void	setup_me(aClient *mp)
 	SetMe(mp);
 	mp->serv->snum = find_server_num (ME);
 	/* we don't fill our own IP -> 0 as ip lenght */
-	(void) make_user(mp,0);
+	(void) make_user(mp);
 	istat.is_users++;	/* here, cptr->next is NULL, see make_user() */
 	mp->user->flags |= FLAGS_OPER;
 	mp->serv->up = mp;

--- a/ircd/list.c
+++ b/ircd/list.c
@@ -190,24 +190,24 @@ void	free_client(aClient *cptr)
 }
 
 /*
-** 'make_user' add's an User information block to a client
+** 'make_user' adds a User information block to a client
 ** if it was not previously allocated.
-** iplen is lenght of the IP we want to allocate.
 */
-anUser	*make_user(aClient *cptr, int iplen)
+anUser *make_user(aClient *cptr)
 {
 	Reg	anUser	*user;
 
 	user = cptr->user;
 	if (!user)
-	    {
-		user = (anUser *)MyMalloc(sizeof(anUser) + iplen);
-		memset(user, 0, sizeof(anUser) + iplen);
+	{
+		user = (anUser *)MyMalloc(sizeof(anUser));
+		memset(user, 0, sizeof(anUser));
 
 #ifdef	DEBUGMODE
 		users.inuse++;
 #endif
 		user->away = NULL;
+		user->sip = NULL;
 		user->refcnt = 1;
 		user->joined = 0;
 		user->flags = 0;
@@ -219,7 +219,7 @@ anUser	*make_user(aClient *cptr, int iplen)
 		user->bcptr = cptr;
 		if (cptr->next)	/* the only cptr->next == NULL is me */
 			istat.is_users++;
-	    }
+	}
 	return user;
 }
 
@@ -315,6 +315,11 @@ void	free_user(anUser *user)
 			istat.is_away--;
 			istat.is_awaymem -= (strlen(user->away) + 1);
 			MyFree(user->away);
+		}
+
+		if (user->sip)
+		{
+			MyFree(user->sip);
 		}
 		MyFree(user);
 #ifdef	DEBUGMODE

--- a/ircd/list_ext.h
+++ b/ircd/list_ext.h
@@ -45,7 +45,7 @@ EXTERN void send_listinfo (aClient *cptr, char *name);
 #endif /* DEBUGMOE */
 EXTERN aClient *make_client (aClient *from);
 EXTERN void free_client (aClient *cptr);
-EXTERN anUser *make_user (aClient *cptr, int iplen);
+EXTERN anUser *make_user (aClient *cptr);
 EXTERN aServer *make_server (aClient *cptr);
 EXTERN void free_user (anUser *user);
 EXTERN void free_server (aServer *serv);

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1404,7 +1404,7 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	*/
 	acptr = make_client(cptr);
 	add_client_to_list(acptr);
-	(void)make_user(acptr, strlen(parv[5]));
+	(void) make_user(acptr);
 	/* more corrrect is this, but we don't yet have ->mask, so...
 	acptr->user->servp = find_server_name(sptr->serv->mask->serv->snum);
 	... just remember to change it one day --Beeth */
@@ -1436,7 +1436,7 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	acptr->hopcount = sptr->hopcount;
 	/* The client is already killed if the uid is too long. */
 	strcpy(acptr->uid, uid);
-	strcpy(acptr->user->sip, parv[5]);
+	acptr->user->sip = mystrdup(parv[5]);
 	add_to_uid_hash_table(uid, acptr);
 	{
 	    char	*pv[4];
@@ -2409,8 +2409,8 @@ int	m_user(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	realname = parv[4];
 	
 	inetntop(AF_INET6, (char *)&sptr->ip, ipbuf, sizeof(ipbuf));
-	user = make_user(sptr, strlen(ipbuf));
-	strcpy(user->sip, ipbuf);
+	user = make_user(sptr);
+	user->sip = mystrdup(ipbuf);
 
 	user->servp = me.serv;
 	me.serv->refcnt++;


### PR DESCRIPTION
`sip` contains the source IP address of a user as String.

Currently it is declared as
```
char	sip[1];
```
and its memory is allocated implictly.

I want to refactor it to a pointer (`char *sip`) so that it can be overwritten if needed and to make the code easier to understand.

