### PR TITLE
Adding away-notify IRCv3 capability

### DIFF
--- a/common/send.c
+++ b/common/send.c
@@ -262,7 +262,7 @@ int	send_queued(aClient *to)
 		else
 		    {
 			msg = zip_buffer(to, NULL, &len, 1);
-			
+
 			if (len == -1)
 			       return dead_link(to,
 						"fatal error in zip_buffer()");
@@ -617,7 +617,7 @@ void	sendto_common_channels(aClient *user, char *pattern, ...)
 	out...but I do know the 2nd part will help big client servers
 	fairly well... - Comstud 97/04/24
 */
-     
+
 	if (highest_fd < 50) /* This part optimized for HUB servers... */
 	    {
 		if (MyConnect(user))
@@ -749,6 +749,31 @@ void	sendto_channel_butserv(aChannel *chptr, aClient *from, char *pattern, ...)
 }
 
 /*
+** sendto_channels_butserv_caps
+**
+** Send a message to all members of channels that 'from' is on,
+** who have the specified capabilities, except 'from' itself.
+*/
+void sendto_channels_butserv_caps(aClient *from, int caps, char *pattern, ...)
+{
+	  Reg Link *channels, *lp;
+    Reg aClient *cptr;
+    int len = 0;
+    va_list va;
+
+		if (!from->user)
+		  return 0;
+
+		    // Iterate through all channels the user is on
+    for (channels = from->user->channel; channels; channels = channels->next)
+    {
+        va_start(va, pattern);
+        sendto_channel_butserv_caps(channels->value.chptr, from, CAP_AWAY_NOTIFY, 0, pattern, va);
+        va_end(va);
+    }
+}
+
+/*
  * sendto_channel_butserv_caps
  *
  * Send a message to all members of a channel that are connected to this
@@ -760,7 +785,7 @@ void	sendto_channel_butserv_caps(aChannel *chptr, aClient *from, int caps, int e
 	Reg aClient *acptr, *lfrm = from;
 	int len = 0;
 
-	if (MyClient(from))
+	if (MyClient(from) && caps != CAP_AWAY_NOTIFY)
 	{    /* Always send to the client itself */
 		if ((caps == 0 || HasCap(from, caps)) && (excluded_caps == 0 || !HasCap(from, excluded_caps)))
 		{
@@ -969,7 +994,7 @@ void	sendto_match_butone(aClient *one, aClient *from, char *mask, int what,
 	int	i;
 	aClient *cptr,
 		*srch;
-  
+
 	for (i = 0; i <= highest_fd; i++)
 	    {
 		if (!(cptr = local[i]))
@@ -999,7 +1024,7 @@ void	sendto_match_butone(aClient *one, aClient *from, char *mask, int what,
 				continue;
 		}
 		/* my client, does he match ? */
-		else if (!(IsRegisteredUser(cptr) && 
+		else if (!(IsRegisteredUser(cptr) &&
 			   match_it(cptr, mask, what)))
 		{
 			continue;
@@ -1033,7 +1058,7 @@ void	sendto_ops_butone(aClient *one, char *from, char *pattern, ...)
 	va_end(va);
 	sendto_serv_butone(one, ":%s WALLOPS :%s", from, buf);
 	sendto_flag(SCH_WALLOP, "!%s! %s", from, buf);
-	
+
 	return;
 }
 
@@ -1277,7 +1302,7 @@ void	logfiles_close(void)
 #ifdef LOG_SERVER_CHANNELS
 	int	i;
 	SChan	*shptr;
-	
+
 	for (i = SCH_MAX - 1, shptr = svchans + i; i >= 0; i--, shptr--)
 	{
 		if (shptr->fd >= 0)
@@ -1311,7 +1336,7 @@ void	logfiles_close(void)
  */
 void	sendto_flog(aClient *cptr, char msg, char *username, char *hostname)
 {
-	/* 
+	/*
 	** One day we will rewrite linebuf to malloc()s, but for now
 	** we are lazy. The longest linebuf I saw during last year
 	** was 216. Max auth reply can be 1024, see rfc931_work() and

--- a/common/send_ext.h
+++ b/common/send_ext.h
@@ -46,6 +46,7 @@ EXTERN int sendto_serv_v (aClient *one, int ver, char *pattern, ...);
 EXTERN void sendto_common_channels (aClient *user, char *pattern, ...);
 EXTERN void sendto_channel_butserv (aChannel *chptr, aClient *from,
 				    char *pattern, ...);
+EXTERN void sendto_channels_butserv_caps(aClient *from, int caps, char *pattern, ...);
 EXTERN void sendto_channel_butserv_caps(aChannel *chptr, aClient *from, int caps, int excluded_caps,
 										char *pattern, ...);
 EXTERN void sendto_match_servs (aChannel *chptr, aClient *from,

--- a/common/struct_def.h
+++ b/common/struct_def.h
@@ -67,7 +67,7 @@ typedef struct        LineItem aExtData;
 #define	LDELAYCHASETIMELIMIT	5400	/* WARNING: *DONT* CHANGE THIS!!!! */
 
 #define	READBUF_SIZE	16384	/* used in s_bsd.c *AND* s_zip.c ! */
- 
+
 /*
  * Make up some numbers which should reflect average leaf server connect
  * queue max size.
@@ -438,7 +438,7 @@ struct Zdata {
 #endif
 
 struct LineItem
-{ 
+{
     char    *line;
     struct  LineItem *next;
 };
@@ -625,7 +625,7 @@ struct	stats {
 	u_int	is_loc;	/* local connections made */
 	u_int	is_nosrv; /* user without server */
 	u_long	is_wwcnt; /* number of nicks overwritten in whowas[] */
-	unsigned long long	is_wwt;	/* sum of elapsed time on when 
+	unsigned long long	is_wwt;	/* sum of elapsed time on when
 					** overwriting whowas[] */
 	u_long	is_wwMt;  /* max elapsed time on when overwriting whowas[] */
 	u_long	is_wwmt;  /* min elapsed time on when overwriting whowas[] */
@@ -935,7 +935,7 @@ typedef enum ServerChannels {
 	SCH_CLIENT,
 #endif
 	SCH_OPER,
-	SCH_MAX	
+	SCH_MAX
 } ServerChannels;
 
 /* used for async dns values */
@@ -1012,6 +1012,7 @@ typedef enum ServerChannels {
 #define CAP_IRCNET_EXTENDED_JOIN	0x0002
 #define CAP_MULTI_PREFIX			0x0004
 #define CAP_SASL					0x0008
+#define CAP_AWAY_NOTIFY   0x0010
 
 /* WHO parameter flags */
 #define WHO_FLAG_OPERS_ONLY	0x0001

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -59,7 +59,7 @@ static	int	jp_chname (char *);
 #endif
 
 static	aChannel *get_channel (aClient *, char *, int);
-static	int	set_mode (aClient *, aClient *, aChannel *, int *, 
+static	int	set_mode (aClient *, aClient *, aChannel *, int *,
 			int, char **);
 static	void	free_channel (aChannel *);
 
@@ -259,7 +259,7 @@ static	int	add_modeid(int type, aClient *cptr, aChannel *chptr,
 		{
 			return -1;
 		}
-		
+
 	    }
 	mode = make_link();
 	istat.is_bans++;
@@ -319,7 +319,7 @@ static	Link	*match_modeid(int type, aClient *cptr, aChannel *chptr)
 				if (isdigit(tmp->value.alist->nick[0]))
 				{
 					/* ...perhaps it is UID-ban? */
-					if (match(tmp->value.alist->nick, 
+					if (match(tmp->value.alist->nick,
 						cptr->uid) != 0)
 					{
 						/* no match on UID */
@@ -685,7 +685,7 @@ int	jp_chname(char *chname)
 		{
 			return 1;
 		}
-		cn++; 
+		cn++;
 	}
 	return 0;
 }
@@ -693,7 +693,7 @@ int	jp_chname(char *chname)
 #define IsJPFlag(x)	(((x)->flags & FLAGS_JP))
 #define IsJPChan(x, y)	( ((x) && IsJPFlag((x))) || jp_chname((y)) )
 
-/* 
+/*
 ** This checks for valid combination of channel name and server,
 ** so Japanese channels are not sent to non-Japanese servers.
 **
@@ -841,7 +841,7 @@ void	channel_modes(aClient *cptr, char *mbuf, char *pbuf, aChannel *chptr)
 	return;
 }
 
-static	void	send_mode_list(aClient *cptr, char *chname, Link *top, 
+static	void	send_mode_list(aClient *cptr, char *chname, Link *top,
 			int mask, char flag)
 {
 	Reg	Link	*lp;
@@ -987,7 +987,7 @@ void	send_channel_members(aClient *cptr, aChannel *chptr)
 	if (check_channelmask(&me, cptr, chptr->chname) == -1)
 		return;
 #ifdef JAPANESE
-	/* We do not send channel members to servers that are not prepared 
+	/* We do not send channel members to servers that are not prepared
 	** to handle JIS encoding. */
 	if (!jp_valid(cptr, chptr, NULL))
                 return;
@@ -1105,7 +1105,7 @@ int	m_mode(aClient *cptr, aClient *sptr, int parc, char *parv[])
  * the client cptr to channel chptr.
  * Also sends it to everybody that should get it.
  */
-static	int	set_mode(aClient *cptr, aClient *sptr, aChannel *chptr, 
+static	int	set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
 			int *penalty, int parc, char *parv[])
 {
 	static	Link	chops[MAXMODEPARAMS+3];
@@ -1317,7 +1317,7 @@ static	int	set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
 				for (s = (u_char *)*parv; *s; )
 				    {
 					/* comma cannot be inside key --Beeth */
-					if (*s == ',') 
+					if (*s == ',')
 						*s = '.';
 					if (*s > 0x7f)
 						if (*s > 0xa0)
@@ -1735,7 +1735,7 @@ static	int	set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
 				cp = numeric;
 				break;
 			}
-			
+
 			switch(lp->flags & MODE_WPARAS)
 			{
 			case MODE_BAN :
@@ -1809,7 +1809,7 @@ static	int	set_mode(aClient *cptr, aClient *sptr, aChannel *chptr,
 				if (ischop && lp->value.cptr == sptr &&
 				    lp->flags == (MODE_CHANOP|MODE_DEL))
 				{
-					chptr->reop = timeofday + 
+					chptr->reop = timeofday +
 						LDELAYCHASETIMELIMIT +
 						myrand() % 300;
 				}
@@ -1975,7 +1975,7 @@ static	int	can_join(aClient *sptr, aChannel *chptr, char *key)
 	Link	*banned;
 	int	limit = 0;
 
-	if (chptr->users == 0 && (bootopt & BOOT_PROT) && 
+	if (chptr->users == 0 && (bootopt & BOOT_PROT) &&
 	    chptr->history != 0 && *chptr->chname != '!')
 		return (timeofday > chptr->history) ? 0 : ERR_UNAVAILRESOURCE;
 
@@ -2275,7 +2275,7 @@ static	void	free_channel(aChannel *chptr)
 	    {
 		while ((tmp = chptr->invites))
 			del_invite(tmp->value.cptr, chptr);
-		
+
 		tmp = chptr->mlist;
 		while (tmp)
 		    {
@@ -2583,6 +2583,13 @@ int	m_join(aClient *cptr, aClient *sptr, int parc, char *parv[])
 									parv[0], chptr->chname, "*", sptr->info);
 		sendto_channel_butserv_caps(chptr, sptr, 0, CAP_EXTENDED_JOIN|CAP_IRCNET_EXTENDED_JOIN,
 									":%s JOIN :%s", parv[0], chptr->chname);
+
+		if (stpr->user->away)
+		{
+			sendto_channel_butserv(chptr, sptr, ":%s AWAY :%s",
+				parv[0], sptr->user->away);
+		}
+
 		del_invite(sptr, chptr);
 		if (chptr->topic[0] != '\0')
 		{
@@ -2620,7 +2627,7 @@ int	m_join(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{
 			sendto_match_servs_v(chptr, cptr, SV_UID,
 				":%s NJOIN %s :%s%s", me.serv->sid, name,
-				flags & CHFL_UNIQOP ? "@@" : 
+				flags & CHFL_UNIQOP ? "@@" :
 				flags & CHFL_CHANOP ? "@" : "",
 				sptr->user ? sptr->uid : parv[0]);
 		}
@@ -2628,7 +2635,7 @@ int	m_join(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{
 			sendto_serv_v(cptr, SV_UID, ":%s NJOIN %s :%s%s",
 				me.serv->sid, name,
-				flags & CHFL_UNIQOP ? "@@" : 
+				flags & CHFL_UNIQOP ? "@@" :
 				flags & CHFL_CHANOP ? "@" : "",
 				sptr->user ? sptr->uid : parv[0]);
 		}
@@ -2694,7 +2701,7 @@ int	m_njoin(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	}
 
 	*uidbuf = '\0'; u = uidbuf;
- 	/* 17 comes from syntax ": NJOIN  :,@@+\r\n\0" */ 
+ 	/* 17 comes from syntax ": NJOIN  :,@@+\r\n\0" */
 	maxlen = BUFSIZE - 17 - strlen(parv[0]) - strlen(parv[1]) - NICKLEN;
 	for (target = strtoken(&p, parv[2], ","); target;
 	     target = strtoken(&p, NULL, ","))
@@ -2916,7 +2923,7 @@ int	m_part(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	** Broadcasted to other servers is ":nick PART #chan,#chans :comment",
 	** so we must make sure buf does not contain too many channels or later
 	** they get truncated! "10" comes from all fixed chars: ":", " PART "
-	** and ending "\r\n\0". We could subtract strlen(comment)+2 here too, 
+	** and ending "\r\n\0". We could subtract strlen(comment)+2 here too,
 	** but it's not something we care, is it? :->
 	** Btw: if we ever change m_part to have UID as source, fix this! --B.
 	*/
@@ -2948,10 +2955,10 @@ int	m_part(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			/* jp_valid here because in else{} there's
 			** sendto_match_servs() which ignores such
 			** channels when sending stuff. --B. */
-			&& jp_valid(NULL, chptr, NULL)	/* XXX-JP: why not 
+			&& jp_valid(NULL, chptr, NULL)	/* XXX-JP: why not
 							jp_valid(NULL, chptr, name)?
-							because user cannot be on 
-							jp-named channel which is not 
+							because user cannot be on
+							jp-named channel which is not
 							flagged JP? --B. */
 #endif
 			)
@@ -3111,7 +3118,7 @@ int	m_kick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				{
 					if (*nbuf)
 					{
-						sendto_match_servs_v(chptr, 
+						sendto_match_servs_v(chptr,
 							cptr, SV_UID,
 							":%s KICK %s %s :%s",
 							sender, name,
@@ -3160,7 +3167,7 @@ int	m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	aChannel *chptr = NullChn;
 	char	*topic = NULL, *name, *p = NULL;
 	int	penalty = 1;
-	
+
 	parv[1] = canonize(parv[1]);
 
 	for (; (name = strtoken(&p, parv[1], ",")); parv[1] = NULL)
@@ -3173,7 +3180,7 @@ int	m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		}
 		if (!UseModes(name))
 		{
-			sendto_one(sptr, replies[ERR_NOCHANMODES], ME, 
+			sendto_one(sptr, replies[ERR_NOCHANMODES], ME,
 				parv[0], name);
 			continue;
 		}
@@ -3194,7 +3201,7 @@ int	m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		/* should never be true at this point --B. */
 		if (check_channelmask(sptr, cptr, name))
 			continue;
-	
+
 		if (parc > 2)
 			topic = parv[2];
 
@@ -3237,7 +3244,7 @@ int	m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
 #ifdef USE_SERVICES
 			check_services_butone(SERVICE_WANT_TOPIC,
 					      NULL, sptr, ":%s TOPIC %s :%s",
-					      parv[0], chptr->chname, 
+					      parv[0], chptr->chname,
 					      chptr->topic);
 #endif
 			penalty += 2;
@@ -3354,20 +3361,20 @@ int	m_list(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	if (parc > 2 &&
 	    hunt_server(cptr, sptr, ":%s LIST %s %s", 2, parc, parv))
 		return 10;
-	
+
 	if (BadPtr(parv[1]))
 	{
 		Link *lp;
 		int listedchannels = 0;
 		int maxsendq = 0;
-		
+
 		if (!sptr->user)
 		{
 			sendto_one(sptr, replies[RPL_LISTEND], ME,
 				   BadTo(parv[0]));
 			return 2;
 		}
-		
+
 #ifdef LIST_ALIS_NOTE
 		if (MyConnect(sptr))
 		{
@@ -3382,7 +3389,7 @@ int	m_list(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		 * here and within following loops as well. - jv
 		 */
 		maxsendq = (int) ((float) get_sendq(sptr, 0) * (float) 0.9);
-		
+
 		/* First, show all +s/+p channels user is on */
 		for (lp = sptr->user->channel; lp; lp = lp->next)
 		{
@@ -3427,9 +3434,9 @@ int	m_list(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 				break;
 			}
-		
+
 		}
-		
+
 end_of_list:;
 #ifdef LIST_ALIS_NOTE
 		/* Send second notice if we listed more than 24 channels
@@ -3441,7 +3448,7 @@ end_of_list:;
 				LIST_ALIS_NOTE);
 		}
 #endif
-	
+
 	}
 	else
 	{
@@ -3476,7 +3483,7 @@ end_of_list:;
 					if (!MyConnect(sptr) &&
 					    rlen > CHREPLLEN)
 						break;
-				}		
+				}
 			}
 		}
 	}
@@ -3498,7 +3505,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 	int 	pxlen, ismember = 0, nlen, maxlen;
 	char 	*pbuf = buf;
 	int	showusers = 1;
-	
+
 	if (!chptr->users)     /* channel in ND */
 	{
 		showusers = 0;
@@ -3508,7 +3515,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 		ismember = (lp = find_channel_link(sptr->user->channel, chptr))
 			   ? 1 : 0;
 	}
-	
+
 	if (SecretChannel(chptr))
 	{
 		if (!ismember)
@@ -3528,7 +3535,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 	{
 		*pbuf++ = '=';
 	}
-	
+
 	if (showusers)
 	{
 		*pbuf++ = ' ';
@@ -3539,7 +3546,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 		*pbuf++ = ':';
 		*pbuf = '\0';
 		pxlen += 4;  /* '[=|*|@]' ' + ' ' + ':'  */
-		
+
 		if (IsAnonymous(chptr))
 		{
 			if (ismember)
@@ -3584,11 +3591,11 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 				 - 1		/* " " */
 				 - pxlen	/* "= #chan :" */
 				 - 2;		/* \r\n  */
-			
+
 			for (lp = chptr->members; lp; lp = lp->next)
 			{
 				acptr = lp->value.cptr;
-				
+
 				nlen = strlen(acptr->name);
 				/* This check is needed for server channels
 				 * when someone removes +a mode from them.
@@ -3598,7 +3605,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 				{
 					continue;
 				}
-				
+
 				/* Exceeded allowed length.  */
 				if (((size_t) pbuf - (size_t) buf) + nlen
 					+ (HasCap(sptr, CAP_MULTI_PREFIX) ? 1 : 0) /* multi-prefix might add a second prefix -- mh */
@@ -3641,7 +3648,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 						*pbuf++ = '+';
 					}
 				}
-	
+
 				memcpy(pbuf, acptr->name, nlen);
 				pbuf += nlen;
 				*pbuf++ = ' ';
@@ -3658,7 +3665,7 @@ static void names_channel(aClient *cptr, aClient *sptr, char *to,
 			   chptr->chname);
 	}
 	return;
-	
+
 }
 
 
@@ -3679,13 +3686,13 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	Reg	Link	*lp;
 	int	maxlen ,pxlen,nlen,cansend = 0, sent = 1;
 	char	*para = parc > 1 ? parv[1] : NULL,*name, *p = NULL, *pbuf = buf;
-	
+
 	if (parc > 2 &&
 	    hunt_server(cptr, sptr, ":%s NAMES %s %s", 2, parc, parv))
 	{
 		return MAXPENALTY;
 	}
-	
+
 	if (!BadPtr(para))
 	{
 		for (; (name = strtoken(&p, parv[1], ",")); parv[1] = NULL)
@@ -3713,7 +3720,7 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			}
 		}
 
-		sent = sent < 2 ? 2 : (sent * MAXCHANNELSPERUSER) / MAXPENALTY;	
+		sent = sent < 2 ? 2 : (sent * MAXCHANNELSPERUSER) / MAXPENALTY;
 		return sent < 2 ? 2 : sent;
 	}
 	/* Client wants all nicks/channels which is seriously cpu intensive
@@ -3728,7 +3735,7 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			names_channel(cptr, sptr, parv[0], chptr, 0);
 		}
 	}
-	
+
 	/* Second, list all non-secret channels */
 	for (chptr = channel; chptr; chptr = chptr->nextch)
 	{
@@ -3761,7 +3768,7 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{
 			continue;
 		}
-		
+
 		lp = acptr->user->channel;
 		cansend = 1;
 		while (lp)
@@ -3784,7 +3791,7 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		{
 			continue;
 		}
-		
+
 		if (((size_t) pbuf - (size_t) buf) + nlen >= maxlen)
 		{
 			*pbuf = '\0';
@@ -3794,13 +3801,13 @@ int	m_names(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			pbuf = buf + pxlen;
 			pbuf[0] = '\0';
 		}
-	
+
 		memcpy(pbuf, acptr->name, nlen);
 		pbuf += nlen;
 		*pbuf++ = ' ';
 		sent = 0;
 	}
-	
+
 	*pbuf = '\0';
 	sendto_one(sptr, replies[RPL_NAMREPLY], ME, parv[0], buf);
 	sendto_one(sptr, replies[RPL_ENDOFNAMES], ME, parv[0], "*");

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -4,7 +4,7 @@
  *		      University of Oulu, Computing Center
  *
  *   See file AUTHORS in IRC package for additional names of
- *   the programmers. 
+ *   the programmers.
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -112,7 +112,7 @@ static int user_modes[]	     = { FLAGS_OPER, 'o',
 ** Parameters:
 **	aClient *next	First client to check
 **	char	*ch	Search string (may include wilds)
-**	      
+**
 */
 aClient	*next_client(aClient *next, char *ch)
 {
@@ -209,7 +209,7 @@ int	hunt_server(aClient *cptr, aClient *sptr, char *command, int server,
 		    && (IsServer(acptr->from)
 			&& !match_service_dist(acptr, sptr->service->dist)))
 		    {
-			sendto_one(sptr, replies[ERR_NOSUCHSERVER], ME, BadTo(parv[0]), 
+			sendto_one(sptr, replies[ERR_NOSUCHSERVER], ME, BadTo(parv[0]),
 				   parv[server]);
 			return(HUNTED_NOSUCH);
 		    }
@@ -217,7 +217,7 @@ int	hunt_server(aClient *cptr, aClient *sptr, char *command, int server,
 			   parv[1], parv[2], parv[3], parv[4],
 			   parv[5], parv[6], parv[7], parv[8]);
 		return(HUNTED_PASS);
-	    } 
+	    }
 	sendto_one(sptr, replies[ERR_NOSUCHSERVER], ME, BadTo(parv[0]), parv[server]);
 	return(HUNTED_NOSUCH);
 }
@@ -372,26 +372,26 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 		{
 			if (xtmp->status != CONF_XLINE)
 				continue;
-			if (!BadPtr(xtmp->host) && 
+			if (!BadPtr(xtmp->host) &&
 				match(xtmp->host, username))
 				continue;
-			if (!BadPtr(xtmp->passwd) && 
+			if (!BadPtr(xtmp->passwd) &&
 				match(xtmp->passwd, sptr->user2))
 				continue;
-			if (!BadPtr(xtmp->name) && 
+			if (!BadPtr(xtmp->name) &&
 				match(xtmp->name, sptr->user3))
 				continue;
-			if (!BadPtr(xtmp->name2) && 
+			if (!BadPtr(xtmp->name2) &&
 				match(xtmp->name2, sptr->info))
 				continue;
-			if (!BadPtr(xtmp->name3) && 
+			if (!BadPtr(xtmp->name3) &&
 				match(xtmp->name3, nick))
 				continue;
 			if (!BadPtr(xtmp->source_ip) &&
 				(match(xtmp->source_ip, (sptr->hostp ?
 				sptr->hostp->h_name : sptr->sockhost)) &&
 				match(xtmp->source_ip, sptr->user->sip) &&
-				strchr(xtmp->source_ip, '/') && 
+				strchr(xtmp->source_ip, '/') &&
 				match_ipmask_client(xtmp->source_ip, sptr, 0)))
 				continue;
 			SetXlined(sptr);
@@ -427,7 +427,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 				count += 1;
 				if (timeofday - last > 300)
 				    {
-					sendto_flag(SCH_AUTH, 
+					sendto_flag(SCH_AUTH,
 	    "iauth may be not running! (refusing new user connections)");
 					last = timeofday;
 				    }
@@ -671,16 +671,16 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 		user->servp->usercnt[0]++;
 		istat.is_user[0]++;
 	}
-	
+
 	check_split();
-	
+
 	if ((istat.is_user[1] + istat.is_user[0]) > istat.is_m_users)
 	{
 
 		istat.is_m_users = istat.is_user[1] + istat.is_user[0];
 		if (timeofday - istat.is_m_users_t >= CLCHSEC)
 		{
-			sendto_flag(SCH_NOTICE, 
+			sendto_flag(SCH_NOTICE,
 				"New highest global client connection: %d",
 				istat.is_m_users);
 			istat.is_m_users_t = timeofday;
@@ -690,7 +690,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 	if (MyConnect(sptr))
 	{
 		char **isup;
-		
+
 		istat.is_unknown--;
 		istat.is_myclnt++;
 		if (istat.is_myclnt > istat.is_m_myclnt)
@@ -764,7 +764,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 			BadTo(parv[0]),	*isup);
 			isup++;
 		}
-		
+
 		sendto_one(sptr, replies[RPL_YOURID], ME, BadTo(parv[0]),
 			sptr->uid);
 		(void)m_lusers(sptr, sptr, 1, parv);
@@ -800,7 +800,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 		}
 		send_umode(sptr, sptr, 0, ALL_UMODES, buf);
 		nextping = timeofday;
-		
+
 #ifdef SPLIT_CONNECT_NOTICE
 		if (IsSplit())
 		{
@@ -829,7 +829,7 @@ int	register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 	check_services_butone(SERVICE_WANT_NICK, user->servp, NULL,
 			      "NICK %s :%d", nick, sptr->hopcount+1);
 	check_services_butone(SERVICE_WANT_USER, user->servp, sptr,
-			      ":%s USER %s %s %s :%s", nick, user->username, 
+			      ":%s USER %s %s %s :%s", nick, user->username,
 			      user->host, user->server, sptr->info);
 	if (MyConnect(sptr))	/* all modes about local users */
 		send_umode(NULL, sptr, 0, ALL_UMODES, buf);
@@ -900,7 +900,7 @@ badparamcountkills:
 			}
 			sendto_flag(SCH_ERROR,
 				"Bad NICK param count (%d) from %s via %s: %s NICK%s",
-				parc, sptr->name, 
+				parc, sptr->name,
 				get_client_name(cptr, FALSE),
 				parv[0], buf[0] ? buf : "");
 			return 0;
@@ -967,7 +967,7 @@ badparamcountkills:
 			}
 		}
 	}
-	if (IsServer(cptr) && isdigit(nick[0]) 
+	if (IsServer(cptr) && isdigit(nick[0])
 		&& !strncasecmp(me.serv->sid, nick, SIDLEN))
 	{
 		/* Remote server send us remote user changing his nick
@@ -1113,7 +1113,7 @@ badparamcountkills:
 
 		/* Save acptr */
 		sprintf(path, "(%s@%s[%s](%s) <- %s@%s[%s])",
-			acptr->user->username,	acptr->user->host, 
+			acptr->user->username,	acptr->user->host,
 			acptr->from->name, acptr->name,	user, host, cptr->name);
 		save_user(NULL, acptr, path);
 
@@ -1281,7 +1281,7 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	{
 		sendto_one(sptr, replies[ERR_ERRONEOUSNICKNAME], ME, BadTo(parv[0]),
 			parv[1]);
-		
+
 		ircstp->is_kill++;
 		sendto_flag(SCH_KILL, "Bad UNick: %s From: %s %s", parv[1],
 			parv[0], get_client_name(cptr, FALSE));
@@ -1355,8 +1355,8 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			** save_user().
 			*/
 			sendto_one(cptr,
-				":%s SAVE %s :%s (%s@%s)%s <- (%s@%s)%s", 
-				me.serv->sid, uid, ME, 
+				":%s SAVE %s :%s (%s@%s)%s <- (%s@%s)%s",
+				me.serv->sid, uid, ME,
 				acptr->user->username, acptr->user->host,
 				acptr->user->server, user, host, cptr->name);
 
@@ -1385,7 +1385,7 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				    acptr->from->name,
 				    user, host, get_client_name(cptr, FALSE));
 			ircstp->is_kill++;
-			sendto_serv_butone(NULL, 
+			sendto_serv_butone(NULL,
 				   ":%s KILL %s :%s ((%s@%s)%s <- (%s@%s)%s)",
 				   ME, acptr->name, ME,
 				   (acptr->user) ? acptr->user->username:"???",
@@ -1440,7 +1440,7 @@ int	m_unick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	add_to_uid_hash_table(uid, acptr);
 	{
 	    char	*pv[4];
-	    
+
 	    pv[0] = ME;
 	    pv[1] = acptr->name;
 	    pv[2] = parv[6];
@@ -1482,20 +1482,20 @@ static	int	m_message(aClient *cptr, aClient *sptr, int parc,
 	    {
 		/*
 		** restrict destination list to MAXPENALTY/2 recipients to
-		** solve SPAM problem --Yegg 
-		*/ 
+		** solve SPAM problem --Yegg
+		*/
 		if (2*penalty >= MAXPENALTY) {
 		    if (!notice)
 			    sendto_one(sptr, replies[ERR_TOOMANYTARGETS],
 				       ME, BadTo(parv[0]),
 				       "Too many",nick,"No Message Delivered");
-		    continue;      
-		}   
+		    continue;
+		}
 		/*
 		** nickname addressed?
 		*/
 		if (((IsServer(cptr) || IsService(cptr))
-			&& (acptr = find_uid(nick, NULL))) || 
+			&& (acptr = find_uid(nick, NULL))) ||
 			(acptr = find_person(nick, NULL)))
 		    {
 			if (!notice && MyConnect(sptr) &&
@@ -1521,7 +1521,7 @@ static	int	m_message(aClient *cptr, aClient *sptr, int parc,
 					   ME, BadTo(parv[0]), nick);
 			continue;
 		    }
-	
+
 		/*
 		** the following two cases allow masks in NOTICEs
 		** (for OPERs only)
@@ -1562,7 +1562,7 @@ static	int	m_message(aClient *cptr, aClient *sptr, int parc,
 				continue;
 			}
 			sendto_match_butone(
-				IsServer(cptr) ? cptr : NULL, 
+				IsServer(cptr) ? cptr : NULL,
 				sptr, nick + 2, syntax,
 				":%s %s %s :%s", parv[0],
 				cmd, nick, parv[2]);
@@ -1817,7 +1817,7 @@ static	void	who_channel(aClient *sptr, aChannel *chptr, struct who_opts *opts)
 ** who_find
 **	lists all (matching) users.
 **	CPU intensive, but what can be done?
-**	
+**
 **	Reduced CPU load - 05/2001
 */
 static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
@@ -1825,7 +1825,7 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 	aChannel *chptr = NULL;
 	Link	*lp,*lp2;
 	aClient	*acptr;
-	
+
 	/* first, show INvisible matching users on common channels */
 	if (sptr->user) /* service can request who as well */
 	for (lp = sptr->user->channel; lp ;lp = lp->next)
@@ -1836,22 +1836,22 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 		for (lp2 = chptr->members; lp2 ;lp2 = lp2->next)
 		{
 			acptr = lp2->value.cptr;
-			
+
 			if (!IsInvisible(acptr)
 			    || (acptr->flags & FLAGS_HIDDEN))
 			{
 				continue;
 			}
-			
+
 			if ((opts->flags & WHO_FLAG_OPERS_ONLY) && !IsAnOper(acptr))
 			{
 				continue;
 			}
-			
+
 			/* Mark user with FLAGS_HIDDEN to prevent multiple
 			 * checking.
 			 */
-			
+
 			acptr->flags |= FLAGS_HIDDEN;
 			if (!mask ||
 			     match(mask, acptr->name) == 0 ||
@@ -1860,23 +1860,23 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 			     match(mask, acptr->user->server) == 0 ||
 			     match(mask, acptr->info) == 0)
 				who_one(sptr, acptr, chptr, NULL, opts);
-		
+
 		}
 	}
 
 	for (acptr = client; acptr; acptr = acptr->next)
 	{
-			
+
 		if (!IsPerson(acptr))
 			continue;
-		
+
 		/* clear the flag */
 		if (acptr->flags & FLAGS_HIDDEN)
 		{
 			acptr->flags &= ~FLAGS_HIDDEN;
 			continue;
 		}
-		
+
 		/* allow local opers to see matching clients
 		 * on _LOCAL_ server and show the user himself */
 		if (IsInvisible(acptr) && (acptr != sptr)
@@ -1885,7 +1885,7 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 		{
 			continue;
 		}
-		
+
 		/* we wanted only opers */
 		if ((opts->flags & WHO_FLAG_OPERS_ONLY) && !IsAnOper(acptr))
 		{
@@ -1905,7 +1905,7 @@ static	void	who_find(aClient *sptr, char *mask, struct who_opts *opts)
 		     match(mask, acptr->info) == 0)
 			who_one(sptr, acptr, NULL, NULL, opts);
 	}
-	
+
 }
 
 void parse_who_arg(char *arg, struct who_opts *opts) {
@@ -2019,7 +2019,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	for (p = NULL, mask = strtoken(&p, parv[1], ",");
 	    mask && penalty <= MAXPENALTY;
 		mask = strtoken(&p, NULL, ","))
-	{ 
+	{
 		channame = NULL;
 		penalty += 1;
 
@@ -2032,7 +2032,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			continue;
 
 		/*
-		** We can never have here !mask 
+		** We can never have here !mask
 		** or *mask == '\0', since it would be equal
 		** to parc == 1, that is 'WHO' and/or would not
 		** pass through above for loop.
@@ -2063,7 +2063,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			*/
 			channame = mask;
 		}
-		
+
 		if (IsChannelName(channame))
 		{
 			chptr = find_channel(channame, NULL);
@@ -2079,7 +2079,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				penalty += 1;
 			}
 		}
-		else 
+		else
 		{
 			aClient	*acptr = NULL;
 
@@ -2107,7 +2107,7 @@ int	m_who(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				** All nice chances lost above.
 				** We must hog our server with that.
 				*/
-				
+
 				/* simplify mask */
 				(void)collapse(mask);
 
@@ -2260,7 +2260,7 @@ int	m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 	tmp = mystrdup(parv[1]);
 
-	for (tmp2 = canonize(tmp); (nick = strtoken(&p, tmp2, ",")); 
+	for (tmp2 = canonize(tmp); (nick = strtoken(&p, tmp2, ","));
 		tmp2 = NULL)
 	    {
 		int	invis, showperson, member, wilds;
@@ -2399,7 +2399,7 @@ int	m_user(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		return 1;
    	    }
 	if ((username = (char *)index(parv[1],'@')))
-		*username = '\0'; 
+		*username = '\0';
 
 	/* Copy parameters into better documenting variables */
 
@@ -2407,7 +2407,7 @@ int	m_user(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	umodes   = parv[2];
 	server   = parv[3];
 	realname = parv[4];
-	
+
 	inetntop(AF_INET6, (char *)&sptr->ip, ipbuf, sizeof(ipbuf));
 	user = make_user(sptr);
 	user->sip = mystrdup(ipbuf);
@@ -2477,7 +2477,7 @@ int	m_user(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		}
 	}
 	user->server = find_server_string(me.serv->snum);
-	
+
 	reorder_client_in_list(sptr);
 	if (sptr->info != DefInfo)
 		MyFree(sptr->info);
@@ -2570,7 +2570,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		if (!(acptr = get_history(user, (long)KILLCHASETIMELIMIT)))
 		    {
 			if (!IsServer(sptr))
-				sendto_one(sptr, replies[ERR_NOSUCHNICK], 
+				sendto_one(sptr, replies[ERR_NOSUCHNICK],
 					   ME, BadTo(parv[0]), user);
 			return 1;
 		    }
@@ -2621,7 +2621,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	if (IsService(acptr))
 	{
 		sendto_flag(SCH_KILL, "Received KILL message for %s[%s]. "
-			"From %s Path: %s!%s", acptr->name, 
+			"From %s Path: %s!%s", acptr->name,
 			isdigit(acptr->service->servp->sid[0]) ?
 			acptr->service->servp->sid : "2.10", parv[0], inpath,
 			path);
@@ -2631,7 +2631,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		sendto_flag(SCH_KILL, "Received KILL message for "
 			"%s!%s@%s[%s/%s]. From %s Path: %s!%s",
 			acptr->name, acptr->user->username, acptr->user->host,
-			acptr->user->servp->bcptr->name, 
+			acptr->user->servp->bcptr->name,
 			isdigit(acptr->user->servp->sid[0]) ?
 			acptr->user->servp->sid : "2.10", parv[0], inpath,
 			path);
@@ -2642,7 +2642,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		if (IsService(acptr))
 		{
 			syslog(LOG_DEBUG, "KILL From %s For %s[%s] Path %s!%s",
-				parv[0], acptr->name, 
+				parv[0], acptr->name,
 				isdigit(acptr->service->servp->sid[0]) ?
 				acptr->service->servp->sid : "2.10",
 				inpath, path);
@@ -2650,9 +2650,9 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		else
 		{
 			syslog(LOG_DEBUG, "KILL From %s For %s!%s@%s[%s/%s] "
-				"Path %s!%s", parv[0], acptr->name, 
+				"Path %s!%s", parv[0], acptr->name,
 				acptr->user->username, acptr->user->host,
-				acptr->user->servp->bcptr->name, 
+				acptr->user->servp->bcptr->name,
 				isdigit(acptr->user->servp->sid[0]) ?
 				acptr->user->servp->sid : "2.10",
 				inpath, path);
@@ -2681,7 +2681,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		acptr->flags |= FLAGS_KILLED;
 	    }
 #ifdef	USE_SERVICES
-	check_services_butone(SERVICE_WANT_KILL, NULL, sptr, 
+	check_services_butone(SERVICE_WANT_KILL, NULL, sptr,
 			      ":%s KILL %s :%s!%s", parv[0], acptr->name,
 			      inpath, path);
 #endif
@@ -2722,7 +2722,7 @@ int	m_kill(aClient *cptr, aClient *sptr, int parc, char *parv[])
 }
 
 /***********************************************************************
- * m_away() - Added 14 Dec 1988 by jto. 
+ * m_away() - Added 14 Dec 1988 by jto.
  *	    Not currently really working, I don't like this
  *	    call at all...
  *
@@ -2754,9 +2754,12 @@ int	m_away(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			sptr->user->away = NULL;
 		    }
 		if (sptr->user->flags & FLAGS_AWAY)
-			sendto_serv_butone(cptr, ":%s MODE %s :-a",
-				sptr->uid, parv[0]);
-		/* sendto_serv_butone(cptr, ":%s AWAY", parv[0]); */
+		{
+			/*sendto_serv_butone(cptr, ":%s MODE %s :-a",
+				sptr->uid, parv[0]);*/
+		 sendto_serv_butone(cptr, ":%s AWAY", parv[0]);
+		 sendto_channels_butserv_caps(sptr, CAP_AWAY_NOTIFY, ":%s AWAY", parv[0]);
+		}
 		if (MyConnect(sptr))
 			sendto_one(sptr, replies[RPL_UNAWAY], ME, BadTo(parv[0]));
 #ifdef	USE_SERVICES
@@ -2792,8 +2795,10 @@ int	m_away(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		istat.is_away++;
 		istat.is_awaymem += len;
 		away = (char *)MyMalloc(len);
-		sendto_serv_butone(cptr, ":%s MODE %s :+a",
-			sptr->uid, parv[0]);
+		/*sendto_serv_butone(cptr, ":%s MODE %s :+a",
+			sptr->uid, parv[0]);*/
+		sendto_serv_butone(cptr, ":%s AWAY :%s", parv[0], awy2);
+		sendto_channels_butserv_caps(sptr, CAP_AWAY_NOTIFY, ":%s AWAY :%s", parv[0], awy2);
 	    }
 
 	sptr->user->flags |= FLAGS_AWAY;
@@ -2876,7 +2881,7 @@ int	m_pong(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	{
 		sendto_one(sptr, replies[ERR_NOSUCHSERVER], ME, BadTo(parv[0]),
 			   destination);
-		return 2;	
+		return 2;
 	}
 	if (!IsMe(acptr))
 	{
@@ -2965,7 +2970,7 @@ int	m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		send_umode_out(cptr, sptr, old);
  		sendto_one(sptr, replies[RPL_YOUREOPER], ME, BadTo(parv[0]));
 #ifdef	USE_SERVICES
-		check_services_butone(SERVICE_WANT_OPER, sptr->user->servp, 
+		check_services_butone(SERVICE_WANT_OPER, sptr->user->servp,
 				      sptr, ":%s MODE %s :+%c", parv[0],
 				      parv[0], IsOper(sptr) ? 'o' : 'O');
 #endif
@@ -2975,7 +2980,7 @@ int	m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			sptr->user->servp->usercnt[2]++;
 		}
 		logstring = "";
-	}	
+	}
 	else /* Wrong password or attach_conf() failed */
 	{
 		(void)detach_conf(sptr, aconf);
@@ -3050,9 +3055,9 @@ int	m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		/* Modification by pjg */
 	      }
 #endif /* FNAME_OPERLOG */
-	
+
 	} /* logstring != NULL */
-	
+
 	return 3;
     }
 
@@ -3066,7 +3071,7 @@ int	m_oper(aClient *cptr, aClient *sptr, int parc, char *parv[])
 **	parv[1] = password
 **	parv[2] = protocol & server versions (server only)
 **	parv[3] = server id & options (server only)
-**	parv[4] = (optional) link options (server only)                  
+**	parv[4] = (optional) link options (server only)
 */
 int	m_pass(aClient *cptr, aClient *sptr, int parc, char *parv[])
 {
@@ -3085,7 +3090,7 @@ int	m_pass(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	** in m_user(). */
 	if (parc > 2 && parv[2])
 	    {
-		strncpyzt(buf, parv[2], 15); 
+		strncpyzt(buf, parv[2], 15);
 		if (parc > 3 && parv[3])
 		    {
 			strcat(buf, " ");
@@ -3176,7 +3181,7 @@ int	m_ison(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		if ((acptr = find_person(s, NULL)))
 		    {
 			i = strlen(acptr->name);
-			if (len + i > sizeof(buf) - 4)	
+			if (len + i > sizeof(buf) - 4)
 			{
 				/* leave room for " \r\n\0" */
 				break;
@@ -3227,7 +3232,7 @@ int	m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			sendto_one(sptr, replies[ERR_USERSDONTMATCH], ME, BadTo(parv[0]));
 			return 1;
 	    }
- 
+
 	if (parc < 3)
 	    {
 		m = buf;
@@ -3259,7 +3264,7 @@ int	m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				break;
 			case '-' :
 				what = MODE_DEL;
-				break;	
+				break;
 			/* we may not get these,
 			 * but they shouldnt be in default
 			 */
@@ -3299,7 +3304,7 @@ int	m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
 					if (what == MODE_ADD)
 						sptr->user->flags |= flag;
 					else
-						sptr->user->flags &= ~flag;	
+						sptr->user->flags &= ~flag;
 					penalty += 1;
 					break;
 				    }
@@ -3384,7 +3389,7 @@ int	m_umode(aClient *cptr, aClient *sptr, int parc, char *parv[])
 
 	return penalty;
 }
-	
+
 /*
  * send the MODE string for user (user) to connection cptr
  * -avalon
@@ -3491,7 +3496,7 @@ static	void	save_user(aClient *cptr, aClient *sptr, char *path)
 			sptr->user->host, sptr->uid);
 #endif
 	}
-	
+
 	sendto_common_channels(sptr, ":%s NICK :%s",
 			       sptr->name, sptr->uid);
 	add_history(sptr, NULL);
@@ -3499,7 +3504,7 @@ static	void	save_user(aClient *cptr, aClient *sptr, char *path)
 	check_services_butone(SERVICE_WANT_NICK, sptr->user->servp, sptr,
 			      ":%s NICK :%s", sptr->name, sptr->uid);
 #endif
-	sendto_serv_v(cptr, SV_UID, ":%s SAVE %s :%s%c%s", 
+	sendto_serv_v(cptr, SV_UID, ":%s SAVE %s :%s%c%s",
 		cptr ? cptr->serv->sid : me.serv->sid, sptr->uid,
 		cptr ? cptr->name : ME, cptr ? '!' : ' ', path);
 	sendto_flag(SCH_SAVE, "Received SAVE message for %s. Path: %s!%s",
@@ -3519,7 +3524,7 @@ int	m_save(aClient *cptr, aClient *sptr, int parc, char *parv[])
 {
 	aClient *acptr;
 	char *path = (parc > 2) ? parv[2] : "*no-path*";
-	
+
 	if (parc < 2)
 	{
 		sendto_flag(SCH_ERROR, "Save with not enough parameters "


### PR DESCRIPTION
Changed s_user.c to broadcast AWAY when setting/unsetting. Removed MODE +a/-a broadcast. This is so we can notify away message as part of supporting this capability.

Created a method in send.c - to send specified pattern to all channels the user is a part of, this helps for away-notify. 