### PR TITLE
Services : Update of SERVER/SQUIT/UNICK messages

### DIFF
--- a/ircd/s_misc.c
+++ b/ircd/s_misc.c
@@ -756,10 +756,10 @@ static	void	exit_one_client(aClient *cptr, aClient *sptr, aClient *from,
 		}
 #ifdef	USE_SERVICES
 		check_services_butone(SERVICE_WANT_SQUIT, sptr->serv, sptr,
-		                      ":%s SQUIT %s :%s",
-		                      sptr->serv->up->serv->sid,
-		                      sptr->serv->sid,
-		                      comment);
+							  ":%s SQUIT %s :%s",
+							  sptr->serv->up->serv->sid,
+							  sptr->serv->sid,
+							  comment);
 #endif
 		del_from_sid_hash_table(sptr->serv);
 		remove_server_from_tree(sptr);

--- a/ircd/s_misc.c
+++ b/ircd/s_misc.c
@@ -756,8 +756,10 @@ static	void	exit_one_client(aClient *cptr, aClient *sptr, aClient *from,
 		}
 #ifdef	USE_SERVICES
 		check_services_butone(SERVICE_WANT_SQUIT, sptr->serv, sptr,
-				      ":%s SQUIT %s :%s", from->name,
-				      sptr->name, comment);
+		                      ":%s SQUIT %s :%s",
+		                      sptr->serv->up->serv->sid,
+		                      sptr->serv->sid,
+		                      comment);
 #endif
 		del_from_sid_hash_table(sptr->serv);
 		remove_server_from_tree(sptr);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -548,13 +548,13 @@ int    m_smask(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	add_server_to_tree(acptr);
 #ifdef USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
-	                      ":%s SERVER %s %d %s %s :%s",
-	                      acptr->serv->up->serv->sid,
-	                      acptr->name,
-	                      acptr->hopcount + 1,
-	                      acptr->serv->sid,
-	                      acptr->serv->verstr,
-	                      acptr->info);
+						  ":%s SERVER %s %d %s %s :%s",
+						  acptr->serv->up->serv->sid,
+						  acptr->name,
+						  acptr->hopcount + 1,
+						  acptr->serv->sid,
+						  acptr->serv->verstr,
+						  acptr->info);
 #endif
 	/* And introduce the server to others. */
 	introduce_server(cptr, acptr);
@@ -813,13 +813,13 @@ int	m_server(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		introduce_server(cptr, acptr);
 #ifdef	USE_SERVICES
 		check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
-		                      ":%s SERVER %s %d %s %s :%s",
-		                      acptr->serv->up->serv->sid,
-		                      acptr->name,
-		                      hop + 1,
-		                      acptr->serv->sid,
-		                      acptr->serv->verstr,
-		                      acptr->info);
+							  ":%s SERVER %s %d %s %s :%s",
+							  acptr->serv->up->serv->sid,
+							  acptr->name,
+							  hop + 1,
+							  acptr->serv->sid,
+							  acptr->serv->verstr,
+							  acptr->info);
 #endif
 		sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 			    acptr->name, parv[0], hop+1, acptr->info);
@@ -1232,13 +1232,13 @@ int	m_server_estab(aClient *cptr, char *sid, char *versionbuf)
 	add_fd(cptr->fd, &fdas);
 #ifdef	USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, cptr->serv, cptr,
-	                      ":%s SERVER %s %d %s %s :%s",
-	                      cptr->serv->up->serv->sid,
-	                      cptr->name,
-	                      cptr->hopcount + 1,
-	                      cptr->serv->sid,
-	                      cptr->serv->verstr,
-	                      cptr->info);
+						  ":%s SERVER %s %d %s %s :%s",
+						  cptr->serv->up->serv->sid,
+						  cptr->name,
+						  cptr->hopcount + 1,
+						  cptr->serv->sid,
+						  cptr->serv->verstr,
+						  cptr->info);
 #endif
 	sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 		cptr->name, ME, 1, cptr->info);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -549,7 +549,7 @@ int    m_smask(aClient *cptr, aClient *sptr, int parc, char *parv[])
 #ifdef USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
 	                      ":%s SERVER %s %d %s %s :%s",
-	                      acptr->serv->up->name,
+	                      acptr->serv->up->serv->sid,
 	                      acptr->name,
 	                      acptr->hopcount + 1,
 	                      acptr->serv->sid,
@@ -813,9 +813,13 @@ int	m_server(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		introduce_server(cptr, acptr);
 #ifdef	USE_SERVICES
 		check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
-				      ":%s SERVER %s %d %s %s :%s", parv[0],
-				      acptr->name, hop+1, acptr->serv->sid,
-				      acptr->serv->verstr, acptr->info);
+		                      ":%s SERVER %s %d %s %s :%s",
+		                      acptr->serv->up->serv->sid,
+		                      acptr->name,
+		                      hop + 1,
+		                      acptr->serv->sid,
+		                      acptr->serv->verstr,
+		                      acptr->info);
 #endif
 		sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 			    acptr->name, parv[0], hop+1, acptr->info);
@@ -1228,8 +1232,13 @@ int	m_server_estab(aClient *cptr, char *sid, char *versionbuf)
 	add_fd(cptr->fd, &fdas);
 #ifdef	USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, cptr->serv, cptr,
-			      ":%s SERVER %s %d %s %s :%s", ME, cptr->name,
-			      cptr->hopcount+1, cptr->serv->sid, cptr->serv->verstr, cptr->info);
+	                      ":%s SERVER %s %d %s %s :%s",
+	                      cptr->serv->up->serv->sid,
+	                      cptr->name,
+	                      cptr->hopcount + 1,
+	                      cptr->serv->sid,
+	                      cptr->serv->verstr,
+	                      cptr->info);
 #endif
 	sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 		cptr->name, ME, 1, cptr->info);

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -546,7 +546,15 @@ int    m_smask(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	add_to_sid_hash_table(parv[1], acptr);
 
 	add_server_to_tree(acptr);
-
+#ifdef USE_SERVICES
+	check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
+	                      ":%s SERVER %s %d %s :%s",
+	                      acptr->serv->up->name,
+	                      acptr->name,
+	                      acptr->hopcount + 1,
+	                      acptr->serv->sid,
+	                      acptr->info);
+#endif
 	/* And introduce the server to others. */
 	introduce_server(cptr, acptr);
 

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -548,11 +548,12 @@ int    m_smask(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	add_server_to_tree(acptr);
 #ifdef USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
-	                      ":%s SERVER %s %d %s :%s",
+	                      ":%s SERVER %s %d %s %s :%s",
 	                      acptr->serv->up->name,
 	                      acptr->name,
 	                      acptr->hopcount + 1,
 	                      acptr->serv->sid,
+	                      acptr->serv->verstr,
 	                      acptr->info);
 #endif
 	/* And introduce the server to others. */
@@ -812,9 +813,9 @@ int	m_server(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		introduce_server(cptr, acptr);
 #ifdef	USE_SERVICES
 		check_services_butone(SERVICE_WANT_SERVER, acptr->serv, acptr,
-				      ":%s SERVER %s %d %s :%s", parv[0],
+				      ":%s SERVER %s %d %s %s :%s", parv[0],
 				      acptr->name, hop+1, acptr->serv->sid,
-				      acptr->info);
+				      acptr->serv->verstr, acptr->info);
 #endif
 		sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 			    acptr->name, parv[0], hop+1, acptr->info);
@@ -1227,8 +1228,8 @@ int	m_server_estab(aClient *cptr, char *sid, char *versionbuf)
 	add_fd(cptr->fd, &fdas);
 #ifdef	USE_SERVICES
 	check_services_butone(SERVICE_WANT_SERVER, cptr->serv, cptr,
-			      ":%s SERVER %s %d %s :%s", ME, cptr->name,
-			      cptr->hopcount+1, cptr->serv->sid, cptr->info);
+			      ":%s SERVER %s %d %s %s :%s", ME, cptr->name,
+			      cptr->hopcount+1, cptr->serv->sid, cptr->serv->verstr, cptr->info);
 #endif
 	sendto_flag(SCH_SERVER, "Received SERVER %s from %s (%d %s)",
 		cptr->name, ME, 1, cptr->info);

--- a/ircd/s_service.c
+++ b/ircd/s_service.c
@@ -198,15 +198,15 @@ static	void	sendnum_toone(aClient *cptr, int wants, aClient *sptr,
 
 	if ((wants & SERVICE_WANT_UID) && sptr->user)
 		sendto_one(cptr, ":%s UNICK %s %s %s %s %s %s %s :%s",
-			sptr->user->servp->sid,
-			(wants & SERVICE_WANT_NICK) ? sptr->name : ".",
-			sptr->uid,
-			(wants & SERVICE_WANT_USER) ? sptr->user->username : ".",
-			(wants & SERVICE_WANT_USER) ? sptr->user->host : ".",
-			(wants & SERVICE_WANT_USER) ? get_client_ip(sptr) : ".",
-			(wants & (SERVICE_WANT_UMODE|SERVICE_WANT_OPER)) ? umode : "+",
- 		    (wants & SERVICE_WANT_USER) ? (IsSASLAuthed(sptr) ? sptr->sasl_user : "*") : "",
-			(wants & SERVICE_WANT_USER) ? sptr->info : "");
+				   sptr->user->servp->sid,
+				   (wants & SERVICE_WANT_NICK) ? sptr->name : ".",
+				   sptr->uid,
+				   (wants & SERVICE_WANT_USER) ? sptr->user->username : ".",
+				   (wants & SERVICE_WANT_USER) ? sptr->user->host : ".",
+				   (wants & SERVICE_WANT_USER) ? get_client_ip(sptr) : ".",
+				   (wants & (SERVICE_WANT_UMODE | SERVICE_WANT_OPER)) ? umode : "+",
+				   (wants & SERVICE_WANT_USER) ? (IsSASLAuthed(sptr) ? sptr->sasl_user : "*") : "",
+				   (wants & SERVICE_WANT_USER) ? sptr->info : "");
 	else
 	if (wants & SERVICE_WANT_EXTNICK)
 		/* extended NICK syntax */
@@ -673,13 +673,13 @@ int	m_servset(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			split = (MyConnect(acptr) &&
 				 mycmp(acptr->name, acptr->sockhost));
 			sendto_one(sptr, ":%s SERVER %s %d %s %s :%s",
-			           acptr->serv->up->serv->sid,
-			           acptr->name,
-			           acptr->hopcount + 1,
-			           acptr->serv->sid,
-			           acptr->serv->verstr,
-			           acptr->info);
-		    }
+					   acptr->serv->up->serv->sid,
+					   acptr->name,
+					   acptr->hopcount + 1,
+					   acptr->serv->sid,
+					   acptr->serv->verstr,
+					   acptr->info);
+			}
 	    }
 
 	if (burst & (SERVICE_WANT_NICK|SERVICE_WANT_USER|SERVICE_WANT_SERVICE))

--- a/ircd/s_service.c
+++ b/ircd/s_service.c
@@ -671,10 +671,11 @@ int	m_servset(aClient *cptr, aClient *sptr, int parc, char *parv[])
 				continue;
 			split = (MyConnect(acptr) &&
 				 mycmp(acptr->name, acptr->sockhost));
-			sendto_one(sptr, ":%s SERVER %s %d %s :%s",
+			sendto_one(sptr, ":%s SERVER %s %d %s %s :%s",
 				acptr->serv->up->name, acptr->name,
 				acptr->hopcount+1,
 				acptr->serv->sid,
+				acptr->serv->verstr,
 				acptr->info);
 		    }
 	    }

--- a/ircd/s_service.c
+++ b/ircd/s_service.c
@@ -197,7 +197,7 @@ static	void	sendnum_toone(aClient *cptr, int wants, aClient *sptr,
 		umode = "+";
 
 	if ((wants & SERVICE_WANT_UID) && sptr->user)
-		sendto_one(cptr, ":%s UNICK %s %s %s %s %s %s :%s",
+		sendto_one(cptr, ":%s UNICK %s %s %s %s %s %s %s :%s",
 			sptr->user->servp->sid,
 			(wants & SERVICE_WANT_NICK) ? sptr->name : ".",
 			sptr->uid,
@@ -205,6 +205,7 @@ static	void	sendnum_toone(aClient *cptr, int wants, aClient *sptr,
 			(wants & SERVICE_WANT_USER) ? sptr->user->host : ".",
 			(wants & SERVICE_WANT_USER) ? get_client_ip(sptr) : ".",
 			(wants & (SERVICE_WANT_UMODE|SERVICE_WANT_OPER)) ? umode : "+",
+ 		    (wants & SERVICE_WANT_USER) ? (IsSASLAuthed(sptr) ? sptr->sasl_user : "*") : "",
 			(wants & SERVICE_WANT_USER) ? sptr->info : "");
 	else
 	if (wants & SERVICE_WANT_EXTNICK)

--- a/ircd/s_service.c
+++ b/ircd/s_service.c
@@ -672,11 +672,12 @@ int	m_servset(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			split = (MyConnect(acptr) &&
 				 mycmp(acptr->name, acptr->sockhost));
 			sendto_one(sptr, ":%s SERVER %s %d %s %s :%s",
-				acptr->serv->up->name, acptr->name,
-				acptr->hopcount+1,
-				acptr->serv->sid,
-				acptr->serv->verstr,
-				acptr->info);
+			           acptr->serv->up->serv->sid,
+			           acptr->name,
+			           acptr->hopcount + 1,
+			           acptr->serv->sid,
+			           acptr->serv->verstr,
+			           acptr->info);
 		    }
 	    }
 


### PR DESCRIPTION
### SQUIT message
Changed to use the server-to-server format.

From:
```
:<uplink-name> SQUIT <name> :<comment>
```

To:

```
:<uplink-sid> SQUIT <sid> :<comment>
```
 
## SERVER message
Changed to use the server-to-server format.
 
From:
```
:<uplink-name> SERVER <name> <hopcount> <sid> :<info>
```

To:
```
:<uplink-sid> SERVER <name> <hopcount> <sid> <version> :<info>
```

## Servers behind mask
If a server receives `SMASK`, it should notify local services using a `SERVER` message. Currently servers behind mask are only sent during the burst.

## UNICK message
If both `SERVICE_WANT_UID` and `SERVICE_WANT_USER` are set, the format changes.

From:
```
:<sid> UNICK <nick> <uid> <user> <host> <ip> <umode> :<info>
```

To:
```
:<sid> UNICK <nick> <uid> <user> <host> <ip> <umode> <sasl-user> :<info>
```